### PR TITLE
Add AWS CDK Workshop to resources

### DIFF
--- a/src/DotnetFoundationWeb/input/__data/presentations/aws-cdk-workshop.md
+++ b/src/DotnetFoundationWeb/input/__data/presentations/aws-cdk-workshop.md
@@ -1,0 +1,7 @@
+---
+type: workshop
+id: aws-cdk-workshop
+title: AWS CDK .NET WORKSHOP
+link: https://cdkworkshop.com/40-dotnet.html
+content: AWS CDK allows developers to define their cloud infrastructure in code instead of writing large JSON or YAML files. .NET developers can build their cloud infrastructure in C# or F# taking advantages of .NET compilers and tools to validate their infrastructure.
+---


### PR DESCRIPTION
Add the AWS CDK as a workshop in the resources section. The CDK is a project for defining cloud infrastructure in code including .NET.