### PR TITLE
Fix broken link

### DIFF
--- a/input/projects/data/umbraco.md
+++ b/input/projects/data/umbraco.md
@@ -11,7 +11,7 @@ Web: http://umbraco.com/
 ## Project Details
 * [Project Info Site](https://umbraco.com/) 
 * [Project Code Site](https://github.com/umbraco/Umbraco-CMS) 
-* Project License Type: [MIT](https://github.com/umbraco/Umbraco-CMS/blob/7.2.0/LICENSE.md)
+* Project License Type: [MIT](https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/LICENSE.md)
 * Project Main Contacts: [Umbraco Team](https://umbraco.com/about-us/team.aspx) 
 
 ## Quicklinks


### PR DESCRIPTION
https://our.umbraco.org/contribute is still broken, but changing it to https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/.github/CONTRIBUTING.md will not help. The default branch name has changed at least 3 times since the last update.