### PR TITLE
Add config.yml with link for newsletter draft

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Newsletter Update
+    url: https://github.com/dotnet-foundation/website/edit/master/input/blog/posts/_current-newsletter-draft.md
+    about: Newsletter updates are handled via editing the current newsletter draft file.


### PR DESCRIPTION
Follow-up from https://github.com/dotnet-foundation/newsletter/issues/82

This will add a link in the issues list that will take someone to the edit view for the correct newsletter file.

The other issue templates should continue to appear above it, and should look as they do now. They don't need to be listed in this config to work.