### PR TITLE
Fix up layouts

### DIFF
--- a/Generator.csproj
+++ b/Generator.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.11.23" />
-    <PackageReference Include="Statiq.Web" Version="1.0.0-alpha.20" />
+    <PackageReference Include="Statiq.Web" Version="1.0.0-alpha.21" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
   </ItemGroup>
 

--- a/input/_BasicPageLayout.cshtml
+++ b/input/_BasicPageLayout.cshtml
@@ -7,7 +7,7 @@
     <div class="page-section_container container">
         <div class="page-section_row row">
             <div class="col-12">
-                @RenderBody();
+                @RenderBody()
             </div>
         </div>
     </div>

--- a/input/about/board-of-directors.cshtml
+++ b/input/about/board-of-directors.cshtml
@@ -1,6 +1,5 @@
 ﻿---
 title: .NET Foundation Board of Directors
-layout: _layout
 permalink: /about/board-of-directors
 ---
 

--- a/input/about/code-of-conduct.cshtml
+++ b/input/about/code-of-conduct.cshtml
@@ -1,6 +1,5 @@
 ﻿---
 title: .NET Foundation Code of Conduct
-layout: _layout
 permalink: /about/code-of-conduct
 ---
 

--- a/input/about/election/campaign-2019/andreia-gaita.md
+++ b/input/about/election/campaign-2019/andreia-gaita.md
@@ -1,6 +1,5 @@
 ---
 title: Andreia Gaita
-layout: _layout
 image: campaign-2019/54570031-38e78900-499a-11e9-9d03-bf2db6f885d6.jpg
 ---
 

--- a/input/about/election/campaign-2019/andrey-akinshin.md
+++ b/input/about/election/campaign-2019/andrey-akinshin.md
@@ -1,6 +1,5 @@
 ---
 title: Andrey Akinshin
-layout: _layout
 image: campaign-2019/764aadea-1e93-48f6-97b8-e226388603ee.jpg
 ---
 

--- a/input/about/election/campaign-2019/antoine-hemery.md
+++ b/input/about/election/campaign-2019/antoine-hemery.md
@@ -1,6 +1,5 @@
 ---
 title: Antoine Hémery
-layout: _layout
 image: campaign-2019/02a016a5-1f38-46db-87a8-304f6e233d8e.jpg
 ---
 

--- a/input/about/election/campaign-2019/ben-adams.md
+++ b/input/about/election/campaign-2019/ben-adams.md
@@ -1,6 +1,5 @@
 ---
 title: Ben Adams
-layout: _layout
 image: ben-adams.jpg
 elected: true
 twitter: ben_a_adams

--- a/input/about/election/campaign-2019/beth-massi.md
+++ b/input/about/election/campaign-2019/beth-massi.md
@@ -1,6 +1,5 @@
 ---
 title: Beth Massi
-layout: _layout
 image: beth-massi.jpg
 appointed: true
 elected: true

--- a/input/about/election/campaign-2019/claire-novotny.md
+++ b/input/about/election/campaign-2019/claire-novotny.md
@@ -1,6 +1,5 @@
 ---
 title: Claire Novotny
-layout: _layout
 image: claire-novotny.jpg
 elected: false
 team: true

--- a/input/about/election/campaign-2019/daron-yondem.md
+++ b/input/about/election/campaign-2019/daron-yondem.md
@@ -1,6 +1,5 @@
 ---
 title: Daron Yondem
-layout: _layout
 image: campaign-2019/91d8775a-b129-4321-97f1-4eff32632f5b.jpg
 ---
 

--- a/input/about/election/campaign-2019/dave-glick.md
+++ b/input/about/election/campaign-2019/dave-glick.md
@@ -1,6 +1,5 @@
 ---
 title: Dave Glick
-layout: _layout
 image: campaign-2019/53698333-3a655e80-3da9-11e9-931e-39ae72bf1104.jpg
 ---
 

--- a/input/about/election/campaign-2019/david-dieruf.md
+++ b/input/about/election/campaign-2019/david-dieruf.md
@@ -1,6 +1,5 @@
 ---
 title: David Dieruf
-layout: _layout
 image: campaign-2019/54227549-637aa300-44bd-11e9-8b88-bdd2c9060684.png
 ---
 

--- a/input/about/election/campaign-2019/david-pine.md
+++ b/input/about/election/campaign-2019/david-pine.md
@@ -1,6 +1,5 @@
 ---
 title: David Pine
-layout: _layout
 image: campaign-2019/me.png
 ---
 

--- a/input/about/election/campaign-2019/eric-sink.md
+++ b/input/about/election/campaign-2019/eric-sink.md
@@ -1,6 +1,5 @@
 ---
 title: Eric Sink
-layout: _layout
 image: campaign-2019/1c6f3c17-9342-4909-bc3d-1d47f1b4a3eb.jpg
 ---
 

--- a/input/about/election/campaign-2019/erik-schierboom.md
+++ b/input/about/election/campaign-2019/erik-schierboom.md
@@ -1,6 +1,5 @@
 ---
 title: Erik Schierboom
-layout: _layout
 image: campaign-2019/58637674-8a9a-42bc-ad62-47447d176f0f.jpg
 ---
 

--- a/input/about/election/campaign-2019/gary-ewan-park.md
+++ b/input/about/election/campaign-2019/gary-ewan-park.md
@@ -1,6 +1,5 @@
 ---
 title: Gary Ewan Park
-layout: _layout
 image: campaign-2019/5d90914a-07bd-4f92-aab0-9df026779702.jpg
 ---
 

--- a/input/about/election/campaign-2019/ginny-caughey.md
+++ b/input/about/election/campaign-2019/ginny-caughey.md
@@ -1,6 +1,5 @@
 ---
 title: Ginny Caughey
-layout: _layout
 image: campaign-2019/53746947-38b29e00-3e70-11e9-982a-a0ddb0a9134b.jpg
 ---
 

--- a/input/about/election/campaign-2019/iris-classon.md
+++ b/input/about/election/campaign-2019/iris-classon.md
@@ -1,6 +1,5 @@
 ---
 title: Iris Classon
-layout: _layout
 image: iris-classon.jpg
 elected: true
 twitter: irisclasson

--- a/input/about/election/campaign-2019/jamie-rees.md
+++ b/input/about/election/campaign-2019/jamie-rees.md
@@ -1,6 +1,5 @@
 ---
 title: Jamie Rees
-layout: _layout
 image: campaign-2019/0c009f81-0d27-4796-92e8-eb49aa1aa7f8.jpg
 ---
 

--- a/input/about/election/campaign-2019/jessica-white.md
+++ b/input/about/election/campaign-2019/jessica-white.md
@@ -1,6 +1,5 @@
 ---
 title: Jessica White
-layout: _layout
 image: campaign-2019/4fabcac7-d0af-4c01-856b-4fa14cbbcd29.jpg
 ---
 

--- a/input/about/election/campaign-2019/jon-skeet.md
+++ b/input/about/election/campaign-2019/jon-skeet.md
@@ -1,6 +1,5 @@
 ---
 title: Jon Skeet
-layout: _layout
 image: jon-skeet.jpg
 elected: true
 twitter: jonskeet

--- a/input/about/election/campaign-2019/joseph-guadagno.md
+++ b/input/about/election/campaign-2019/joseph-guadagno.md
@@ -1,6 +1,5 @@
 ---
 title: Joseph Guadagno
-layout: _layout
 image: campaign-2019/77475b18-f681-4cd0-87d3-44b952733153.jpg
 ---
 

--- a/input/about/election/campaign-2019/lea-wegner.md
+++ b/input/about/election/campaign-2019/lea-wegner.md
@@ -1,6 +1,5 @@
 ---
 title: Lea Wegner
-layout: _layout
 image: campaign-2019/7fdddbc7-57d2-4ece-9f64-edaae7c0521b.jpg
 ---
 

--- a/input/about/election/campaign-2019/luce-carter.md
+++ b/input/about/election/campaign-2019/luce-carter.md
@@ -1,6 +1,5 @@
 ---
 title: Luce Carter
-layout: _layout
 image: campaign-2019/b6ee3715-63f8-4999-b548-0060867f3915.jpg
 ---
 

--- a/input/about/election/campaign-2019/maira-wenzel.md
+++ b/input/about/election/campaign-2019/maira-wenzel.md
@@ -1,6 +1,5 @@
 ---
 title: Maira Wenzel
-layout: _layout
 image: campaign-2019/acb757aa-e39f-43c6-9edc-7873606a21ba.jpg
 ---
 

--- a/input/about/election/campaign-2019/marc-bruins.md
+++ b/input/about/election/campaign-2019/marc-bruins.md
@@ -1,6 +1,5 @@
 ---
 title: Marc Bruins
-layout: _layout
 image: campaign-2019/2f388304-927f-44b4-9d2e-8e9e3c2ebc90.jpg
 ---
 

--- a/input/about/election/campaign-2019/martijn-laarman.md
+++ b/input/about/election/campaign-2019/martijn-laarman.md
@@ -1,6 +1,5 @@
 ---
 title: Martijn Laarman
-layout: _layout
 image: campaign-2019/683a145a-53a3-4d41-88f9-1d573316d5a8.jpg
 ---
 

--- a/input/about/election/campaign-2019/mattias-karlsson.md
+++ b/input/about/election/campaign-2019/mattias-karlsson.md
@@ -1,6 +1,5 @@
 ---
 title: Mattias Karlsson
-layout: _layout
 image: campaign-2019/53631166-3521db80-3c12-11e9-8946-01c0c4da2d61.png
 ---
 

--- a/input/about/election/campaign-2019/mikayla-hutchinson.md
+++ b/input/about/election/campaign-2019/mikayla-hutchinson.md
@@ -1,6 +1,5 @@
 ---
 title: Mikayla Hutchinson
-layout: _layout
 image: campaign-2019/2fe859ef-0341-463e-ac01-9abb34a94ad9.jpg
 ---
 

--- a/input/about/election/campaign-2019/mitchel-sellers.md
+++ b/input/about/election/campaign-2019/mitchel-sellers.md
@@ -1,6 +1,5 @@
 ---
 title: Mitchel Sellers
-layout: _layout
 image: campaign-2019/17bbbf3e-c635-4802-bfb7-846d9e21b150.jpg
 ---
 

--- a/input/about/election/campaign-2019/morten-nielsen.md
+++ b/input/about/election/campaign-2019/morten-nielsen.md
@@ -1,6 +1,5 @@
 ---
 title: Morten Nielsen
-layout: _layout
 image: campaign-2019/53655225-71e6d600-3c04-11e9-89b9-69ce1261e53b.png
 ---
 

--- a/input/about/election/campaign-2019/natallia-dzenisenka.md
+++ b/input/about/election/campaign-2019/natallia-dzenisenka.md
@@ -1,6 +1,5 @@
 ---
 title: Natallia Dzenisenka
-layout: _layout
 image: campaign-2019/33b689c1-f30e-4859-8f92-76a91914ebd9.jpg
 ---
 

--- a/input/about/election/campaign-2019/nate-barbettini.md
+++ b/input/about/election/campaign-2019/nate-barbettini.md
@@ -1,6 +1,5 @@
 ---
 title: Nate Barbettini
-layout: _layout
 image: campaign-2019/9b3f5b7e-4ad6-43aa-b453-253ba66503d8.jpg
 ---
 

--- a/input/about/election/campaign-2019/peter-mbanugo.md
+++ b/input/about/election/campaign-2019/peter-mbanugo.md
@@ -1,6 +1,5 @@
 ---
 title: Peter Mbanugo
-layout: _layout
 image: campaign-2019/7560ad40-ccaa-4bd9-b5d8-967f9bcb31cd.jpg
 ---
 

--- a/input/about/election/campaign-2019/phil-haack.md
+++ b/input/about/election/campaign-2019/phil-haack.md
@@ -1,6 +1,5 @@
 ---
 title: Phil Haack
-layout: _layout
 image: phil-haack.jpg
 elected: true
 twitter: haacked

--- a/input/about/election/campaign-2019/pratik-khandelwal.md
+++ b/input/about/election/campaign-2019/pratik-khandelwal.md
@@ -1,6 +1,5 @@
 ---
 title: Pratik Khandelwal
-layout: _layout
 image: campaign-2019/54035164-bc58eb80-41de-11e9-9faf-e717eba0165a.jpg
 ---
 

--- a/input/about/election/campaign-2019/robert-mclaws.md
+++ b/input/about/election/campaign-2019/robert-mclaws.md
@@ -1,6 +1,5 @@
 ---
 title: Robert McLaws
-layout: _layout
 image: campaign-2019/53609747-504f0580-3b96-11e9-979d-0727bcc63f42.png
 ---
 

--- a/input/about/election/campaign-2019/robin-krom.md
+++ b/input/about/election/campaign-2019/robin-krom.md
@@ -1,6 +1,5 @@
 ---
 title: Robin Krom
-layout: _layout
 image: campaign-2019/2a562e01-9cda-4202-a901-4c1850cb33c9.jpg
 ---
 

--- a/input/about/election/campaign-2019/rodrigo-diaz-concha.md
+++ b/input/about/election/campaign-2019/rodrigo-diaz-concha.md
@@ -1,6 +1,5 @@
 ---
 title: Rodrigo Díaz Concha
-layout: _layout
 image: campaign-2019/RDC_Portrait_Small.jpg
 ---
 

--- a/input/about/election/campaign-2019/sam-basu.md
+++ b/input/about/election/campaign-2019/sam-basu.md
@@ -1,6 +1,5 @@
 ---
 title: Sam Basu
-layout: _layout
 image: campaign-2019/54139990-10d7b300-43f9-11e9-9db5-da607afd907f.png
 ---
 

--- a/input/about/election/campaign-2019/sara-chipps.md
+++ b/input/about/election/campaign-2019/sara-chipps.md
@@ -1,6 +1,5 @@
 ---
 title: Sara Chipps
-layout: _layout
 image: sara-chipps.png
 elected: true
 twitter: SaraJChipps

--- a/input/about/election/campaign-2019/sean-killeen.md
+++ b/input/about/election/campaign-2019/sean-killeen.md
@@ -1,6 +1,5 @@
 ---
 title: Sean Killeen
-layout: _layout
 image: campaign-2019/2148318
 ---
 

--- a/input/about/election/campaign-2019/shaun-walker.md
+++ b/input/about/election/campaign-2019/shaun-walker.md
@@ -1,6 +1,5 @@
 ---
 title: Shaun Walker
-layout: _layout
 image: campaign-2019/shaun-walker.png
 ---
 

--- a/input/about/election/campaign-2019/spencer-schneidenbach.md
+++ b/input/about/election/campaign-2019/spencer-schneidenbach.md
@@ -1,6 +1,5 @@
 ---
 title: Spencer Schneidenbach
-layout: _layout
 image: campaign-2019/fc65339f-e397-483a-b668-85f481062b9b.jpg
 ---
 

--- a/input/about/election/campaign-2019/stefan-stefanov.md
+++ b/input/about/election/campaign-2019/stefan-stefanov.md
@@ -1,6 +1,5 @@
 ---
 title: Stefan Stefanov
-layout: _layout
 image: https://media.licdn.com/dms/image/C5603AQGw_unwLaxKUA/profile-displayphoto-shrink_200_200/0?e=1557964800&v=beta&t=9G1i2O61ylBgcTKBevlKcKp_SN2UFYmLJcPN5vdwkMc
 ---
 

--- a/input/about/election/campaign-2019/steve-gordon.md
+++ b/input/about/election/campaign-2019/steve-gordon.md
@@ -1,6 +1,5 @@
 ---
 title: Steve Gordon
-layout: _layout
 image: campaign-2019/53630658-7dd49700-3c08-11e9-8329-d5d6f27264c2.png
 ---
 

--- a/input/about/election/campaign-2019/sunny-ahuwanya.md
+++ b/input/about/election/campaign-2019/sunny-ahuwanya.md
@@ -1,6 +1,5 @@
 ---
 title: Sunny Ahuwanya
-layout: _layout
 image: campaign-2019/54499348-16486800-48e7-11e9-8aa0-ef9cd15a002d.jpg
 ---
 

--- a/input/about/election/campaign-2019/toni-solarin-sodara.md
+++ b/input/about/election/campaign-2019/toni-solarin-sodara.md
@@ -1,6 +1,5 @@
 ---
 title: Toni Solarin-Sodara
-layout: _layout
 image: campaign-2019/cdebee6f-bbf9-4f0c-b5d6-0f7fd629cfb3.jpg
 ---
 

--- a/input/about/election/campaign-2019/virgile-bello.md
+++ b/input/about/election/campaign-2019/virgile-bello.md
@@ -1,6 +1,5 @@
 ---
 title: Virgile Bello
-layout: _layout
 image: campaign-2019/54175230-5ebdeb00-44cd-11e9-8b5f-d9b760065e97.jpg
 ---
 

--- a/input/about/election/campaign-2020/_directory.yaml
+++ b/input/about/election/campaign-2020/_directory.yaml
@@ -1,1 +1,1 @@
-layout: _BasicPageLayout
+layout: "/_BasicPageLayout.cshtml"

--- a/input/about/election/campaign-2020/ben-adams.md
+++ b/input/about/election/campaign-2020/ben-adams.md
@@ -4,8 +4,4 @@ twitter: ben_a_adams
 image: ben-adams.jpg
 ---
 
-<section class="page-section">
-    <div class="page-section_container container">
 
-    </div>
-</section>

--- a/input/about/election/campaign-2020/bill-wagner.md
+++ b/input/about/election/campaign-2020/bill-wagner.md
@@ -4,9 +4,6 @@ twitter: billwagner
 image: bill-wagner.jpg
 ---
 
-<section class="page-section">
-    <div class="page-section_container container">
-
 ## Why I'm running
 
 I've been fortunate enough to have success in this industry since starting my career. I've reached the stage where my main focus is to help others achieve their own success. That focus helps further the mission of the .NET Foundation by creating an environment where more people can achieve success in the .NET ecosystem. My day job is to create learning content for .NET developers of all experience levels. That works enables new developers to use the platform for their first apps, developers on other platforms compare their current environment to .NET, and experienced .NET developers learn the platform more deeply.
@@ -27,6 +24,3 @@ I've been on the [.NET Foundation advisory council](https://dotnetfoundation.org
 
 - GitHub: [@BillWagner](https://github.com/BillWagner)
 - Twitter: [@billwagner](https://twitter.com/billwagner)
-
-    </div>
-</section>

--- a/input/about/election/campaign-2020/dennie-declercq.md
+++ b/input/about/election/campaign-2020/dennie-declercq.md
@@ -4,9 +4,6 @@ twitter: DennieDeclercq
 image: campaign-2020/dennie-declercq.jpg
 ---
 
-<section class="page-section">
-    <div class="page-section_container container">
-
 # Why I’m Running
 
 ## *#DreamingIsBelieving continues… With this awesome nomination…*
@@ -35,6 +32,3 @@ My story on Microsoft Humans of IT https://techcommunity.microsoft.com/t5/humans
 Twitter @DennieDeclercq
 FB: https://www.facebook.com/dennie.declercq
 LinkedIn: https://www.linkedin.com/in/dennie-declercq-822086a2/
-
-    </div>
-</section>

--- a/input/about/election/campaign-2020/dhananjay-kumar.md
+++ b/input/about/election/campaign-2020/dhananjay-kumar.md
@@ -4,8 +4,4 @@ twitter: debug_mode
 image: 
 ---
 
-<section class="page-section">
-    <div class="page-section_container container">
 
-    </div>
-</section>

--- a/input/about/election/campaign-2020/huei-feng.md
+++ b/input/about/election/campaign-2020/huei-feng.md
@@ -4,9 +4,6 @@ twitter: feng_huei
 image: campaign-2020/huei-feng.jpg
 ---
 
-<section class="page-section">
-    <div class="page-section_container container">
-      
 ## Why I'm Running
 
 .NET is my passion. I love open source very much. I hope that the .NET ecosystem can flourish in the projects that people think about. I am a very enthusiastic and active member of the .NET community. I have been working in blogs, tweets, forums, conferences, user groups, video
@@ -38,6 +35,3 @@ He is very active on public speech, he has given a number of talks in areas such
 
 * Twitter: [@huifeng](https://twitter.com/feng_huei)
 * GitHub: [@huifeng](https://github.com/hueifeng)
-</div>
-</section>
-

--- a/input/about/election/campaign-2020/jamie-howarth.md
+++ b/input/about/election/campaign-2020/jamie-howarth.md
@@ -4,9 +4,6 @@ twitter: jamiehowarth0
 image: 
 ---
 
-<section class="page-section">
-    <div class="page-section_container container">
-
 # .NET Foundation Campaign: Jamie Howarth
 
 ## Why I'm Running
@@ -35,5 +32,3 @@ I've submitted various patches, pull requests & helped to improve & maintain var
 * LinkedIn: [@jamiehowarth0](https://linkedin.com/in/jamiehowarth0)
 * StackOverflow: [@jamie-howarth](https://stackoverflow.com/users/418297/jamie-howarth)
 
-    </div>
-</section>

--- a/input/about/election/campaign-2020/javier-lozano.md
+++ b/input/about/election/campaign-2020/javier-lozano.md
@@ -4,9 +4,6 @@ twitter: jglozano
 image: campaign-2020/javier-lozano.jpg
 ---
 
-<section class="page-section">
-    <div class="page-section_container container">
-
 # .NET Foundation Campaign: Javier Lozano
 Hello, it's a pleasure to meet you virtually! My name is Javier Lozano, and I am running for the .NET Foundation Board of Directors.
 I'm a Microsoft MVP for the past 14 years, have contributed to different open source projects, as well as ASP.NET. Also, I am the co-creator of .NET Conf, the largest virtual conference for .NET.
@@ -35,5 +32,3 @@ The one thing I've learned from running .NET Conf for the past 10 years is that 
 * Twitter: [@jglozano](https://twitter.com/jglozano)
 * GitHub: [@jglozano](https://github.com/jglozano)
 
-    </div>
-</section>

--- a/input/about/election/campaign-2020/jay-harris.md
+++ b/input/about/election/campaign-2020/jay-harris.md
@@ -4,9 +4,6 @@ twitter: jayharris
 image: campaign-2020/jay-harris.jpg
 ---
 
-<section class="page-section">
-    <div class="page-section_container container">
-
 # .NET Foundation Campaign: Jay Harris
 
 ## Why am I running?
@@ -38,5 +35,3 @@ If you have questions about my candidacy or goals with the .NET Foundation, plea
 * [@jayharris](https://github.com/jayharris) on GitHub
 * [LinkedIn](https://www.linkedin.com/in/jasonharris/)
 
-    </div>
-</section>

--- a/input/about/election/campaign-2020/jeff-strauss.md
+++ b/input/about/election/campaign-2020/jeff-strauss.md
@@ -4,9 +4,6 @@ twitter: jeffreystrauss
 image: campaign-2020/jeff-strauss.jpg
 ---
 
-<section class="page-section">
-    <div class="page-section_container container">
-
 # .NET Foundation Campaign: Jeff Strauss
 
 ## Who is Jeff?
@@ -48,5 +45,3 @@ If you have questions about my candidacy or objectives for the .NET Foundationâ€
 * GitHub: [@jstrauss](https://github.com/jstrauss)
 * Email: [jeffstrauss.netfoundation@gmail.com](mailto:jeffstrauss.netfoundation@gmail.com)
 
-    </div>
-</section>

--- a/input/about/election/campaign-2020/jeffrey-chilberto.md
+++ b/input/about/election/campaign-2020/jeffrey-chilberto.md
@@ -4,9 +4,6 @@ twitter: JChilberto
 image: campaign-2020/jeffrey-chilberto.jpg
 ---
 
-<section class="page-section">
-    <div class="page-section_container container">
-
 # .NET Foundation Campaign: Jeffrey Chilberto
 
 ## Why I'm Running
@@ -37,5 +34,3 @@ I do not have a personal blog but instead contribute to the .Net community by wr
 * Microsoft Tech Community: [Jeffrey Chilberto](https://techcommunity.microsoft.com/t5/user/viewprofilepage/user-id/141713)
 * Twitter: [@JChilberto](https://twitter.com/jchilberto)
 
-    </div>
-</section>

--- a/input/about/election/campaign-2020/jerome-hardaway.md
+++ b/input/about/election/campaign-2020/jerome-hardaway.md
@@ -4,9 +4,6 @@ twitter: JeromeHardaway
 image: campaign-2020/jerome-hardaway.jpg
 ---
 
-<section class="page-section">
-    <div class="page-section_container container">
-
 # .NET Foundation Campaign: Jerome Hardaway
 
 ## Who am I?
@@ -45,5 +42,3 @@ careers - Documentary was nominated for an Emmy
 * Twitter: [@JeromeHardaway](https://twitter.com/JeromeHardaway)
 * GitHub: [@JeromeHardaway](https://github.com/jeromehardaway)
 
-    </div>
-</section>

--- a/input/about/election/campaign-2020/joseph-guadagno.md
+++ b/input/about/election/campaign-2020/joseph-guadagno.md
@@ -4,9 +4,6 @@ twitter: jguadagno
 image: campaign-2020/joseph-guadagno.jpg
 ---
 
-<section class="page-section">
-    <div class="page-section_container container">
-
 # .NET Foundation Campaign: Joseph Guadagno
 
 ## About Me
@@ -75,5 +72,3 @@ A list of some of my open source projects
 * [StackOverflow](https://stackoverflow.com/users/89184/joseph-guadagno)
 * Email: [jguadagno@hotmail.com](mailto:jguadagno@hotmail.com)
 
-    </div>
-</section>

--- a/input/about/election/campaign-2020/layla-porter.md
+++ b/input/about/election/campaign-2020/layla-porter.md
@@ -4,9 +4,6 @@ twitter: LaylaCodesIt
 image: campaign-2020/layla-porter.jpg
 ---
 
-<section class="page-section">
-    <div class="page-section_container container">
-
 # .NET Foundation Campaign: Layla Porter
 
 ## Who am I?
@@ -45,5 +42,3 @@ I blog for the [Twilio website](https://www.twilio.com/blog/author/lporter), all
 * Twitch: [@LaylaCodesIt](https://twitch.tv/LaylaCodesIt)
 * GitHub: [@Layla-P](https://github.com/Layla-p)
 
-    </div>
-</section>

--- a/input/about/election/campaign-2020/mitchel-sellers.md
+++ b/input/about/election/campaign-2020/mitchel-sellers.md
@@ -4,9 +4,6 @@ twitter: mitchelsellers
 image: campaign-2020/mitchel-sellers.jpg
 ---
 
-<section class="page-section">
-    <div class="page-section_container container">
-
 # .NET Foundation Campaign: Mitchel Sellers
 
 ## Why I'm Running
@@ -48,5 +45,3 @@ Of the most recent experiences from these boards, I lead the successful migratio
 * GitHub: [@mitchelsellers](https://github.com/mitchelsellers)
 * Email: [msellers@iowacomputergurus.com](mailto:msellers@iowacomputergurus.com)
 
-    </div>
-</section>

--- a/input/about/election/campaign-2020/rainer-stropek.md
+++ b/input/about/election/campaign-2020/rainer-stropek.md
@@ -4,9 +4,6 @@ twitter: rstropek
 image: campaign-2020/rainer-stropek.jpg
 ---
 
-<section class="page-section">
-    <div class="page-section_container container">
-
 # .NET Foundation Campaign: Rainer Stropek
 
 ## Why I'm Running
@@ -50,5 +47,3 @@ My daily job is building cloud solutions based on Azure and .NET in my own compa
 * Twitter: [@rstropek](https://twitter.com/rstropek)
 * GitHub: [@rstropek](https://github.com/rstropek)
 
-    </div>
-</section>

--- a/input/about/election/campaign-2020/rodney-littles-ii.md
+++ b/input/about/election/campaign-2020/rodney-littles-ii.md
@@ -4,8 +4,4 @@ twitter:
 image: 
 ---
 
-<section class="page-section">
-    <div class="page-section_container container">
 
-    </div>
-</section>

--- a/input/about/election/campaign-2020/rodrigo-diaz-concha.md
+++ b/input/about/election/campaign-2020/rodrigo-diaz-concha.md
@@ -4,9 +4,6 @@ twitter: rdiazconcha
 image: campaign-2020/rodrigo-diaz-concha.jpg
 ---
 
-<section class="page-section">
-    <div class="page-section_container container">
-
 # .NET Foundation Campaign: Rodrigo Díaz Concha
 
 
@@ -42,5 +39,3 @@ One way to give back to the community is to help any developer who wishes to ado
 * [about.me](https://rdiazconcha.me/)
 * [Goodreads](https://goodreads.com/rdiazconcha)
 
-    </div>
-</section>

--- a/input/about/election/campaign-2020/shawn-wildermuth.md
+++ b/input/about/election/campaign-2020/shawn-wildermuth.md
@@ -4,9 +4,6 @@ twitter: shawnwildermuth
 image: campaign-2020/shawn-wildermuth.jpg
 ---
 
-<section class="page-section">
-    <div class="page-section_container container">
-
 # .NET Foundation Campaign: Shawn Wildermuth
 
 ## Who am I?
@@ -58,5 +55,3 @@ You can see some of my talks from conferences and user groups at my blog:
 - [YouTube](https://youtube.com/c/swildermuth)
 - [Amazon Author Page](http://www.amazon.com/-/e/B001H6ME46)
 
-    </div>
-</section>

--- a/input/about/election/campaign.cshtml
+++ b/input/about/election/campaign.cshtml
@@ -1,5 +1,4 @@
 ---
-layout: _layout
 title: Interested in running?
 permalink: about/election/campaign
 ---

--- a/input/about/election/candidates.cshtml
+++ b/input/about/election/candidates.cshtml
@@ -1,5 +1,4 @@
 ﻿---
-layout: _layout
 title: Campaign Statements
 permalink: about/election/candidates
 ---

--- a/input/about/election/example.md
+++ b/input/about/election/example.md
@@ -1,5 +1,4 @@
 ﻿---
-layout: _layout
 image: /img/dot_bot.png
 permalink: about/election/example
 ---

--- a/input/about/election/index.cshtml
+++ b/input/about/election/index.cshtml
@@ -1,5 +1,4 @@
 ---
-layout: _layout
 title: .NET Foundation Board Member Elections
 permalink: about/election
 ---

--- a/input/about/election/questions.md
+++ b/input/about/election/questions.md
@@ -1,5 +1,4 @@
 ---
-layout: _layout
 title: Ask the Candidates a Question!
 permalink: about/election/questions
 ---

--- a/input/about/election/results.cshtml
+++ b/input/about/election/results.cshtml
@@ -1,5 +1,4 @@
 ﻿---
-layout: _layout
 title: Election Results
 permalink: about/election/results
 ---

--- a/input/about/faq.cshtml
+++ b/input/about/faq.cshtml
@@ -1,6 +1,5 @@
 ﻿---
 title: .NET Foundation FAQ
-layout: _layout
 permalink: /about/faq
 ---
 

--- a/input/about/index.cshtml
+++ b/input/about/index.cshtml
@@ -1,7 +1,6 @@
 ---
 title: About the .NET Foundation
 description: The .NET Foundation is an independent organization created to foster innovation, which we believe starts with open development and collaboration. It's also a forum for community and commercial developers to broaden and strengthen the future of the .NET ecosystem.
-layout: _layout
 permalink: /about
 ---
 

--- a/input/about/privacy-policy.cshtml
+++ b/input/about/privacy-policy.cshtml
@@ -1,7 +1,6 @@
 ﻿---
 title: .NET Foundation Privacy Policy
 description: .NET Foundation privacy policy
-layout: _layout
 permalink: /about/privacy-policy
 ---
 

--- a/input/about/team/chris-sfanos.md
+++ b/input/about/team/chris-sfanos.md
@@ -1,6 +1,5 @@
 ---
 title: Chris Sfanos
-layout: _layout
 image: chris-sfanos.jpg
 order: 4
 twitter: 

--- a/input/about/team/claire-novotny.md
+++ b/input/about/team/claire-novotny.md
@@ -1,6 +1,5 @@
 ---
 title: Claire Novotny
-layout: _layout
 image: claire-novotny.jpg
 order: 1
 twitter: clairernovotny

--- a/input/about/team/jon-galloway.md
+++ b/input/about/team/jon-galloway.md
@@ -1,6 +1,5 @@
 ---
 title: Jon Galloway
-layout: _layout
 image: jon-galloway.png
 order: 2
 twitter: jongalloway

--- a/input/about/team/miklos-barkoczi.md
+++ b/input/about/team/miklos-barkoczi.md
@@ -1,6 +1,5 @@
 ---
 title: Miklos Barkoczi
-layout: _layout
 image: miklos-barkoczi.png
 order: 3
 twitter: 

--- a/input/about/technical-steering-group.cshtml
+++ b/input/about/technical-steering-group.cshtml
@@ -1,6 +1,5 @@
 ---
 title: .NET Foundation Technical Steering Group
-layout: _layout
 permalink: /about/technical-steering-group
 ---
 

--- a/input/blog/archive.cshtml
+++ b/input/blog/archive.cshtml
@@ -2,7 +2,6 @@
 Enumerate: => Inputs.FilterSources("blog/posts/*").Select(x => x.GetDateTime("Published").ToString("yyyy/MM")).Distinct()
 DestinationPath: => new NormalizedPath($"blog/{Current}/index.html")
 Title: => $"Post Archive - {Current}"
-layout: _layout
 ---
 <section class="page-section page-section">
     <div class="page-section_container container">

--- a/input/blog/index.cshtml
+++ b/input/blog/index.cshtml
@@ -1,7 +1,6 @@
 ---
 Title: Blog
 PageTitle: Recent Posts
-layout: _layout
 ---
 <section class="page-section page-section">
   <div class="page-section_container container">

--- a/input/community/committees.cshtml
+++ b/input/community/committees.cshtml
@@ -1,5 +1,4 @@
 ---
-layout: _layout
 permalink: community/committees
 ---
 <section class="page-section page-section--purple">

--- a/input/community/find-a-meetup.cshtml
+++ b/input/community/find-a-meetup.cshtml
@@ -1,5 +1,4 @@
 ﻿---
-layout: _layout
 permalink: /find-a-meetup
 ---
 

--- a/input/community/get-involved.cshtml
+++ b/input/community/get-involved.cshtml
@@ -1,5 +1,4 @@
 ---
-layout: _layout
 permalink: /get-involved
 isCommunityHome: true
 ---

--- a/input/community/host-a-meetup.cshtml
+++ b/input/community/host-a-meetup.cshtml
@@ -1,5 +1,4 @@
 ﻿---
-layout: _layout
 permalink: /host-a-meetup
 ---
 

--- a/input/community/index.cshtml
+++ b/input/community/index.cshtml
@@ -1,5 +1,4 @@
 ﻿---
-layout: _layout
 permalink: /community
 ---
 

--- a/input/community/resources.cshtml
+++ b/input/community/resources.cshtml
@@ -1,5 +1,4 @@
 ---
-layout: _layout
 permalink: /community/resources
 title: ".NET Presentations: Events in a Box!"
 description: "Welcome to .NET \"Presentations in a Box.\"  We have a listing of workshops and presentations YOU can use AND contribute to! Remix and share, and present at Meetups, User Groups, CodeCamps, or Conferences! Not familiar with .NET? Download open source .NET Core for any OS at <a href=\"http://dot.net\">http://dot.net</a> or try it in your browser at <a href=\"http://try.dot.net\">http://try.dot.net</a> now!"

--- a/input/example.md
+++ b/input/example.md
@@ -1,6 +1,5 @@
 ---
 title: Example
-layout: _layout
 image: /img/dot_bot.png
 Excluded: true
 ---

--- a/input/index.cshtml
+++ b/input/index.cshtml
@@ -1,7 +1,6 @@
 ---
 title: .NET Foundation
 description: You've found the heartbeat of .NET - where projects and communities come together to get things done in our open-source world. Share your skills for the greater good. Meet in person, get involved virtually, and stay on top of the latest news, meetups, and events.
-layout: _layout
 isHome: true
 ---
 <section id="home-hero">

--- a/input/member/become-a-member.cshtml
+++ b/input/member/become-a-member.cshtml
@@ -1,6 +1,5 @@
 ﻿---
 title: Become a Member of the .NET Foundation
-layout: _layout
 permalink: /become-a-member
 ---
 

--- a/input/member/corporate-sponsors.cshtml
+++ b/input/member/corporate-sponsors.cshtml
@@ -1,5 +1,4 @@
 ﻿---
-layout: _layout
 permalink: /corporate-sponsors
 title: Corporate Sponsors
 ---

--- a/input/member/index.cshtml
+++ b/input/member/index.cshtml
@@ -1,7 +1,6 @@
 ﻿---
 title: .NET Foundation
 description: Independent. Innovative. And always open source.
-layout: _layout
 permalink: /
 ---
 

--- a/input/news.cshtml
+++ b/input/news.cshtml
@@ -1,7 +1,6 @@
 ---
 title: .NET Foundation news
 description: Keep an eye on this page for news from us, news about .NET, and most important, updates from your peers. Contributors are commended.
-layout: _layout
 permalink: /news
 ---
 

--- a/input/projects/data/_ViewStart.cshtml
+++ b/input/projects/data/_ViewStart.cshtml
@@ -1,3 +1,3 @@
 @{
-    Layout = @"/projects/data/_Layout.cshtml";
+    Layout = @"_Layout.cshtml";
 }

--- a/input/projects/index.cshtml
+++ b/input/projects/index.cshtml
@@ -1,7 +1,6 @@
 ---
 title: .NET Foundation Projects
 description: Projects and the people behind them are at the heart of what .NET Foundation is all about. These days, you’ll find a wide variety of projects, including the .NET Compiler Platform, ASP.NET, .NET Core, and Xamarin Forms, along with the popular .NET open-source frameworks xUnit and Reactive Extensions.
-layout: _layout
 permalink: /projects
 ---
 

--- a/input/projects/net-foundation-project-committee.cshtml
+++ b/input/projects/net-foundation-project-committee.cshtml
@@ -1,5 +1,4 @@
 ---
-layout: _layout
 permalink: /projects/net-foundation-project-committee
 ---
 <section class="page-section page-section">

--- a/input/projects/submit.cshtml
+++ b/input/projects/submit.cshtml
@@ -1,6 +1,5 @@
 ---
 title: .NET Foundation Submit Project
-layout: _layout
 permalink: /projects/submit
 ---
 

--- a/input/projects/why-join.cshtml
+++ b/input/projects/why-join.cshtml
@@ -1,5 +1,4 @@
 ---
-layout: _layout
 permalink: /projects/why-join
 ---
 


### PR DESCRIPTION
This PR:
- Bumps the Statiq.Web version to get a bunch of fixes to Razor layout paths and metadata.
- Removes a bunch of stale layout metadata from the pre-Statiq days (this front matter didn't actually do anything before, but it might cause problems going forward since layout metadata now works).
- Removes the temporary HTML layout elements from the 2020 candidate Markdown pages.
- Fixes a couple layout paths now that layout path finding bugs are resolved in the latest Statiq version.