### PR TITLE
Revert "Exclude /api from sitemap.xml"

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -28,7 +28,7 @@ namespace DotnetFoundationWeb
         .AddSetting(Keys.Host, "dotnetfoundation.org")
         .AddSetting(Keys.LinksUseHttps, true)
         .AddSetting(WebKeys.MirrorResources, true)
-        .AddSetting(WebKeys.ExcludedPaths, "api/")
+        .AddSetting(WebKeys.ExcludedPaths, "api/node_modules")
         .BuildPipeline(
             "GenerateProjectsJson",
             builder => builder


### PR DESCRIPTION
Reverts dotnet-foundation/website#182

This excluded all of the api folder. We need that. Just not in the sitemap.