### PR TITLE
Create channels.md

### DIFF
--- a/input/projects/data/channels.md
+++ b/input/projects/data/channels.md
@@ -1,0 +1,17 @@
+---
+Title: Channels [Archived]
+Contributor: David Fowler
+Logo: dotnet-platform.png
+Web: https://github.com/davidfowl/Channels
+---
+# Channels
+
+[Channels](https://github.com/davidfowl/Channels) is a push based .NET Streams project.  It has been archived and replaced with [Pipelines (System.IO.Pipelines)](https://github.com/dotnet/corefxlab)
+
+## Project Details
+
+* [Project Info Site](https://github.com/davidfowl/Channels)
+* [Project Code Site](https://github.com/davidfowl/Channels)
+* Project License Type: [Apache 2.0](https://github.com/davidfowl/Channels/blob/master/LICENSE.md)
+* Project Main Contacts: [David Fowler](https://github.com/davidfowl).
+


### PR DESCRIPTION
Adding projects to the Projects page that aren't currently listed.  This will include archived and other older projects.  Goal is to keep the Projects page representing an accurate view of everything in the .NET Foundation portfolio