### PR TITLE
Update sourcelink-legacy.md

### DIFF
--- a/input/projects/data/sourcelink-legacy.md
+++ b/input/projects/data/sourcelink-legacy.md
@@ -3,7 +3,7 @@ Title: SourceLink 🔚
 ---
 # SourceLink
 
-Update: The recommended library to use now is [SourceLink](sourcelink)
+Update: The recommended library to use now is [SourceLink](/projects/sourcelink)
 
  Source link support allows source code to be downloaded on demand while debugging. SourceLink is a set of build tools to help create and test for source link support. [Source link support](https://github.com/dotnet/core/blob/master/Documentation/diagnostics/source_link.md) is a developer productivity feature that allows unique information about an assembly's original source code to be embedded in its PDB during compilation.  
 


### PR DESCRIPTION
Fix broken URL pointing to /sourcelink instead of /projects/sourcelink