### PR TITLE
Create corewf.md

### DIFF
--- a/input/projects/data/corewf.md
+++ b/input/projects/data/corewf.md
@@ -1,0 +1,21 @@
+---
+Title: CoreWF
+Contributor: UIPath
+Logo: dotnet-platform.png
+Web: https://github.com/UiPath-Open/corewf
+---
+# CoreWF
+
+[CoreWF](https://github.com/UiPath-Open/corewf) is a port of the Windows Workflow Foundation (WF) runtime to .NET Core and .NET Standard.
+
+## Project Details
+
+* [Project Info Site](https://github.com/UiPath-Open/corewf)
+* [Project Code Site](https://github.com/UiPath-Open/corewf)
+* Project License Type: [MIT](https://github.com/UiPath-Open/corewf/blob/master/LICENSE)
+* Project Main Contacts: [Lucian Bargaoanu](https://github.com/lbargaoanu) and [Dustin Metzgar](https://github.com/dmetzgar).
+
+## Quicklinks
+
+* [Documentation](https://github.com/UiPath-Open/corewf/blob/master/LICENSE)
+* [Contribute](https://github.com/UiPath-Open/corewf/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
Adding CoreWF back to the projects page.  It appears to not have transferred over during the migration.  Used the original PR to validate data