### PR TITLE
SEO: Update_page_title

### DIFF
--- a/input/member/index.cshtml
+++ b/input/member/index.cshtml
@@ -1,5 +1,5 @@
 ﻿---
-title: .NET Foundation
+title: .NET Foundation | Become a member
 description: Independent. Innovative. And always open source.
 permalink: /
 ---


### PR DESCRIPTION
Updated duplicate page title.

**FYI:**  The title tag is considered one of the most important on-page SEO factors, and can help both users and search engines to quickly understand what content they can expect to find on the page.

If multiple pages have the same title, this can make it difficult for search engines to differentiate the 'best' page for a given search query, which can result in keyword cannibalization (multiple pages on your own site competing for the same search terms, and hurting each others' rankings).