### PR TITLE
Ignore .idea from JetBrains Product Line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ TestResult.xml
 .vscode
 *.pfx
 projects-content.json
+.idea/
 
 functions/node_modules/
 input/api/issues/index.js


### PR DESCRIPTION
This ignores the .idea folder for folks working
on the DNF website using tools like JetBrains Rider.