### PR TITLE
refresh meetups page

### DIFF
--- a/input/community/meetups.cshtml
+++ b/input/community/meetups.cshtml
@@ -43,7 +43,7 @@ permalink: /meetups
 <section class="page-section">
     <div class="page-section_container container">
         <div class="page-section_row row h-100">
-            <div class="page-section_column col-sm-8 text-right">
+            <div class="page-section_column col-md-8 text-md-right order-2 order-md-1">
                 <h2>
                     Find a meetup
                 </h2>
@@ -56,7 +56,7 @@ permalink: /meetups
                 </div>
             </div>
 
-            <div class="col-sm-4 col-lg-3 offset-lg-1 my-auto px-3">
+            <div class="col-md-4 col-lg-3 offset-lg-1 my-auto px-3 order-1 order-md-2 text-center text-lg-left">
                 <img src="img/ic_fluent_people_community_add_24_regular.svg" alt="Find a meetup" />
             </div>
         </div>
@@ -67,10 +67,10 @@ permalink: /meetups
 <section class="page-section page-section--purple">
     <div class="page-section_container container">
         <div class="page-section_row row h-100">
-            <div class="col-sm-4 col-lg-3 offset-lg-1 my-auto px-3">
+            <div class="col-md-4 col-lg-3 offset-lg-1 my-auto px-3 text-center text-lg-left">
                 <img src="img/ic_fluent_globe_video_24_regular_white.svg" alt=".NET Virtual User Group" />
             </div>
-            <div class="page-section_column col-sm-8 text-left">
+            <div class="page-section_column col-md-8 text-left">
                 <h2>
                     .NET Virtual User Group
                 </h2>
@@ -90,7 +90,7 @@ permalink: /meetups
 <section class="page-section page-section--purple--light">
     <div class="page-section_container container">
         <div class="page-section_row row h-100">
-            <div class="page-section_column col-sm-8 text-right">
+            <div class="page-section_column col-md-8 text-md-right order-2 order-md-1">
                 <h2>
                     Start a meetup
                 </h2>
@@ -101,7 +101,7 @@ permalink: /meetups
                     <a href="https://aka.ms/add-dotnet-meetup/" class="site-button site-button--pink">Register your meetup</a>
                 </div>
             </div>
-            <div class="col-sm-4 col-lg-3 offset-lg-1 my-auto px-3">
+            <div class="col-md-4 col-lg-3 offset-lg-1 my-auto px-3 order-1 order-md-2 text-center text-lg-left">
                 <img src="img/meetup_logo.png" alt="Host a meetup" />
             </div>
         </div>
@@ -112,10 +112,10 @@ permalink: /meetups
 <section class="page-section page-section--purple">
     <div class="page-section_container container">
         <div class="page-section_row row h-100">
-            <div class="col-sm-4 col-lg-3 offset-lg-1 my-auto px-3">
+            <div class="col-md-4 col-lg-3 offset-lg-1 my-auto px-3 text-center text-lg-left">
                 <img src="img/ic_fluent_reading_list_24_regular.svg" alt="Meetup resources" />
             </div>
-            <div class="page-section_column col-sm-8 text-left">
+            <div class="page-section_column col-md-8 text-left">
                 <h2>
                     Meetup resources
                 </h2>


### PR DESCRIPTION
issue https://github.com/dotnet-foundation/website/issues/344
On mobile devices, all blocks are now like this
![3](https://user-images.githubusercontent.com/26163841/93270892-b1f7b480-f7ba-11ea-883a-f31156e3d622.jpg)
on tablets
![4](https://user-images.githubusercontent.com/26163841/93270920-bde37680-f7ba-11ea-9f07-1630d62170b4.jpg)
on big screens as it was

