### PR TITLE
Changes required for new version of Statiq

### DIFF
--- a/Generator.csproj
+++ b/Generator.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.11.23" />
-    <PackageReference Include="Statiq.Web" Version="1.0.0-beta.3" />
+    <PackageReference Include="Statiq.Web" Version="1.0.0-beta.5" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
   </ItemGroup>
 

--- a/Program.cs
+++ b/Program.cs
@@ -25,6 +25,7 @@ namespace DotnetFoundationWeb
 
             return await Bootstrapper.Factory
               .CreateWeb(args)
+              .AddSetting(WebKeys.InputFiles, new [] { "**/{!_,}*", "_redirects" })
               .AddSetting(Keys.Host, "dotnetfoundation.org")
               .AddSetting(Keys.LinksUseHttps, true)
               .AddSetting(WebKeys.MirrorResources, true)

--- a/input/about/election/candidates.cshtml
+++ b/input/about/election/candidates.cshtml
@@ -8,7 +8,14 @@ permalink: about/election/candidates
         <div class="page-section_row row">
             <div class="col-12">
 
-@if (Inputs.FilterSources("about/election/campaign-2020/*").Count() == 0)
+@{
+    IDocument[] candidates = Outputs
+        .FromPipeline(nameof(Statiq.Web.Pipelines.Content))
+        .FilterSources("about/election/campaign-2020/*.md")
+        .OrderBy(x => x.GetTitle())
+        .ToArray();
+}
+@if (candidates.Length == 0)
 {
     <h3>We're just getting started!</h3>
 
@@ -27,12 +34,7 @@ else
     <p>Check out the <a href="about/election/campaign">details</a> on how the process works.</p>
 
     <section class="card-container">
-        @Html.Partial(
-            "../../_partials/_candidate-card.cshtml",
-            Outputs
-                .FromPipeline(nameof(Statiq.Web.Pipelines.Content))
-                .FilterSources("about/election/campaign-2020/*.md")
-                .OrderBy(x => x.GetTitle()))
+        @Html.Partial("../../_partials/_candidate-card.cshtml", candidates)
     </section>
 }
 

--- a/input/community/committees/outreach.yaml
+++ b/input/community/committees/outreach.yaml
@@ -4,4 +4,4 @@ Chairperson: Sara Chipps
 Image: /assets/members/sara-chipps.png
 Meets: This group meets monthly on the 3rd Tuesday of the Month at 3p ET.
 Repository: https://github.com/dotnet-foundation/wg-outreach
-Order: 3
+Order: 4

--- a/input/manifest.json
+++ b/input/manifest.json
@@ -1,4 +1,6 @@
-﻿{
+﻿ContentType: Asset
+---
+{
   "ShouldOutput": true,
   "name": "App",
   "icons": [

--- a/input/routes.json
+++ b/input/routes.json
@@ -1,3 +1,5 @@
+ContentType: Asset
+---
 { 
   "ShouldOutput": true,
   "routes": [


### PR DESCRIPTION
Updates Statiq to 1.0.0-beta.5 along with resulting changes:
- Added `ContentType: Asset` to the root `.json` files so they'll be copied to output without processing.
- Added the `_redirects` file to `InputFiles` so it gets copied (otherwise, files starting with an underscore are generally ignored).
- Fixed up the code that gets a list of election candidates.
- Fixed a duplicate `Order` value that conflicted with an existing one.