### PR TITLE
Update index.cshtml

### DIFF
--- a/AppSettings.cs
+++ b/AppSettings.cs
@@ -22,13 +22,13 @@ namespace DotnetFoundationWeb
 
         public static string AzureSearchQueryKey { get; set; } = ConfigurationManager.AppSettings["AzureSearchQueryKey"];
 
-        public static string ContributionsCounter { get; set; } = ConfigurationManager.AppSettings["ContributionsCounter"];
+        public static int ContributionsCounter { get; set; } = int.Parse(ConfigurationManager.AppSettings["ContributionsCounter"]);
 
-        public static string CompaniesCounter { get; set; } = ConfigurationManager.AppSettings["CompaniesCounter"];
+        public static int CompaniesCounter { get; set; } = int.Parse(ConfigurationManager.AppSettings["CompaniesCounter"]);
 
-        public static string ActiveProjectsCounter { get; set; } = ConfigurationManager.AppSettings["ActiveProjectsCounter"];
+        public static int ActiveProjectsCounter { get; set; } = int.Parse(ConfigurationManager.AppSettings["ActiveProjectsCounter"]);
 
-        public static string ResourcesCounter { get; set; } = ConfigurationManager.AppSettings["ResourcesCounter"];
+        public static int ResourcesCounter { get; set; } = int.Parse(ConfigurationManager.AppSettings["ResourcesCounter"]);
 
         public static string GoogleAnalytics { get; set; } = ConfigurationManager.AppSettings["GoogleAnalytics"];
 

--- a/input/index.cshtml
+++ b/input/index.cshtml
@@ -62,7 +62,7 @@ isHome: true
             <div class="page-section_column col-lg-3 col-sm-6">
                 <div class="icon-box animated icon-box--grey animation-delay--8 d-flex flex-column align-items-center" data-delay="900">
                     <div class="icon-box_stat">
-                        <span class="counter">@DotnetFoundationWeb.AppSettings.ContributionsCounter</span><span class="icon-plus" style="display:none">+</span>
+                        <span class="counter">@DotnetFoundationWeb.AppSettings.ContributionsCounter.ToString("N0")</span><span class="icon-plus" style="display:none">+</span>
                     </div>
                     <div class="icon-box_icon">
                         <img src="img/developers_icon.png" alt="Contributions">
@@ -75,7 +75,7 @@ isHome: true
             <div class="page-section_column col-lg-3 col-sm-6 pad-fix--sm">
                 <div class="icon-box animated icon-box--grey animation-delay--2 d-flex flex-column align-items-center" data-delay="300">
                     <div class="icon-box_stat">
-                        <span class="counter">@DotnetFoundationWeb.AppSettings.CompaniesCounter</span><span class="icon-plus" style="display:none">+</span>
+                        <span class="counter">@DotnetFoundationWeb.AppSettings.CompaniesCounter.ToString("N0")</span><span class="icon-plus" style="display:none">+</span>
                     </div>
                     <div class="icon-box_icon">
                         <img src="img/building_icon.png" alt="Companies">
@@ -88,7 +88,7 @@ isHome: true
             <div class="page-section_column col-lg-3 col-sm-6 pad-fix--lg">
                 <div class="icon-box animated icon-box--grey animation-delay--4 d-flex flex-column align-items-center" data-delay="500">
                     <div class="icon-box_stat counter">
-                        @DotnetFoundationWeb.AppSettings.ActiveProjectsCounter
+                        @DotnetFoundationWeb.AppSettings.ActiveProjectsCounter.ToString("N0")
                     </div>
                     <div class="icon-box_icon">
                         <img src="img/member_projects_icon.png" alt="Active Projects">
@@ -101,7 +101,7 @@ isHome: true
             <div class="page-section_column col-lg-3 col-sm-6 pad-fix--lg">
                 <div class="icon-box animated icon-box--grey animation-delay--6 d-flex flex-column align-items-center" data-delay="700">
                     <div class="icon-box_stat counter">
-                        @DotnetFoundationWeb.AppSettings.ResourcesCounter
+                        @DotnetFoundationWeb.AppSettings.ResourcesCounter.ToString("N0")
                     </div>
                     <div class="icon-box_icon">
                         <img src="img/github_icon.png" alt="Resources">


### PR DESCRIPTION
Added standard numeric formatting of contributions, companies, active projects, and resource counts on the home screen. Formats numbers such as "3700" as "3,700", and "59275" as "59,275". This will hep with readability.

## Before

![image](https://user-images.githubusercontent.com/7679720/95887504-875f3400-0d45-11eb-83fe-5974805ce6fa.png)

## After

![image](https://user-images.githubusercontent.com/7679720/95887464-7a424500-0d45-11eb-8c93-3e7c5510a5a9.png)

