### PR TITLE
Adds HTTPS validation for speaker links

### DIFF
--- a/Analyzers/SpeakerDataAnalyzer.cs
+++ b/Analyzers/SpeakerDataAnalyzer.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Immutable;
 using Microsoft.Extensions.Logging;
 using Statiq.Common;
+using Statiq.Web.Pipelines;
 
 namespace DotnetFoundationWeb
 {
@@ -8,11 +9,14 @@ namespace DotnetFoundationWeb
     {
         public override LogLevel LogLevel { get; set; } = LogLevel.Error;
 
-        public override string[] Pipelines => new[] { nameof(Statiq.Web.Pipelines.Content) };
-
-        protected override sealed void Analyze(ImmutableArray<IDocument> documents, IAnalyzerContext context)
+        protected SpeakerDataAnalyzer()
         {
-            foreach (IDocument document in documents.FilterSources("community/speakers/*.md"))
+            PipelinePhases.Add(nameof(AnalyzeContent), Phase.Process);
+        }
+
+        protected override sealed void Analyze(IAnalyzerContext context)
+        {
+            foreach (IDocument document in context.Inputs.FilterSources("community/speakers/*.md"))
             {
                 AnalyzeSpeakerData(document, context);
             }

--- a/Analyzers/ValidateSpeakerLinks.cs
+++ b/Analyzers/ValidateSpeakerLinks.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.Extensions.Logging;
 using Statiq.Common;
@@ -9,11 +10,18 @@ namespace DotnetFoundationWeb
     {
         protected override void AnalyzeSpeakerData(IDocument document, IAnalyzerContext context)
         {
-            foreach (string linkKey in SpeakerLinkAttribute.GetAll().Keys)
+            foreach (KeyValuePair<string, SpeakerLinkAttribute> linkAttribute in SpeakerLinkAttribute.GetAll())
             {
-                if (document.ContainsKey(linkKey) && !Uri.TryCreate(document.GetString(linkKey), UriKind.Absolute, out _))
+                if (document.ContainsKey(linkAttribute.Key))
                 {
-                    context.Add(document, $"{linkKey} link {document.GetString(linkKey)} is invalid");
+                    if (!Uri.TryCreate(document.GetString(linkAttribute.Key), UriKind.Absolute, out Uri uri))
+                    {
+                        context.AddAnalyzerResult(document, $"{linkAttribute.Key} link {document.GetString(linkAttribute.Key)} is invalid");
+                    }
+                    else if (linkAttribute.Value.EnforceHttps && uri.Scheme != Uri.UriSchemeHttps)
+                    {
+                        context.AddAnalyzerResult(document, $"{linkAttribute.Key} link should be HTTPS and was not");
+                    }
                 }
             }
         }

--- a/Analyzers/ValidateSpeakerTopics.cs
+++ b/Analyzers/ValidateSpeakerTopics.cs
@@ -72,7 +72,7 @@ namespace DotnetFoundationWeb
             string[] nonApprovedTopics = topics.Where(x => !Topics.Contains(x)).ToArray();
             if (nonApprovedTopics.Length > 0)
             {
-                context.Add(document, $"Document contains non-approved topic(s): {string.Join(", ", nonApprovedTopics)}");
+                context.AddAnalyzerResult(document, $"Document contains non-approved topic(s): {string.Join(", ", nonApprovedTopics)}");
             }
         }
     }

--- a/Generator.csproj
+++ b/Generator.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.11.23" />
     <PackageReference Include="Microsoft.SyndicationFeed.ReaderWriter" Version="1.0.2" />
-    <PackageReference Include="Statiq.Web" Version="1.0.0-beta.7" />
+    <PackageReference Include="Statiq.Web" Version="1.0.0-beta.8" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
   </ItemGroup>
 

--- a/SiteKeys.cs
+++ b/SiteKeys.cs
@@ -13,7 +13,9 @@
         public const string Lat = nameof(Lat);  // Fetched based on Location, but can be explicitly provided
         public const string Lon = nameof(Lon);  // Fetched based on Location, but can be explicitly provided
         public const string Topics = nameof(Topics);
+        [SpeakerLink("fas fa-pencil-alt", false, false)]
         public const string Blog = nameof(Blog);
+        [SpeakerLink(null, false, false)]
         public const string Feed = nameof(Feed);
         [SpeakerLink("fab fa-twitter")]
         public const string Twitter = nameof(Twitter);

--- a/SpeakerLinkAttribute.cs
+++ b/SpeakerLinkAttribute.cs
@@ -7,12 +7,18 @@ namespace DotnetFoundationWeb
 {
     public class SpeakerLinkAttribute : Attribute
     {
-        public SpeakerLinkAttribute(string iconClass)
+        public SpeakerLinkAttribute(string iconClass, bool enforceHttps = true, bool displayOnAddPage = true)
         {
             IconClass = iconClass;
+            EnforceHttps = enforceHttps;
+            DisplayOnAddPage = displayOnAddPage;
         }
 
         public string IconClass { get; set; }
+
+        public bool EnforceHttps { get; set; }
+
+        public bool DisplayOnAddPage { get; set; }
 
         public static Dictionary<string, SpeakerLinkAttribute> GetAll() =>
             typeof(SiteKeys)

--- a/input/_partials/_header.cshtml
+++ b/input/_partials/_header.cshtml
@@ -41,13 +41,13 @@
                   </a>
                   <div class="dropdown-menu" aria-labelledby="membership-dropdown">
                     <a class="dropdown-item" href="/member/corporate-sponsors">Corporate Sponsors</a>
-                    <a class="dropdown-item" href="/member/profile">Profile</a>
+                    <a class="dropdown-item" href="/member/profile" data-no-validate>Profile</a>
                     <a class="dropdown-item" href="/member/become-a-member">Become A Member</a>
                   </div>
                   <div class="mobile-items" aria-labelledby="membership-dropdown--mobile">
                     <a class="dropdown-item" href="/member">Membership</a>
                     <a class="dropdown-item" href="/member/corporate-sponsors">Corporate Sponsors</a>
-                    <a class="dropdown-item" href="/member/profile">Profile</a>
+                    <a class="dropdown-item" href="/member/profile" data-no-validate>Profile</a>
                     <a class="dropdown-item" href="/member/become-a-member">Become A Member</a>
                   </div>
                 </li>

--- a/input/blog/archive.cshtml
+++ b/input/blog/archive.cshtml
@@ -25,5 +25,5 @@ Title: => $"Post Archive - {GetString("Current")}"
 </section>
 
 @section head {
-    <link type="application/rss+xml" rel="alternate" title="Blog" href="/api/rss/" />
+    <link type="application/rss+xml" rel="alternate" title="Blog" href="/api/rss/" data-no-validate />
 }

--- a/input/blog/index.cshtml
+++ b/input/blog/index.cshtml
@@ -24,5 +24,5 @@ PageTitle: Recent Posts
 </section>
 
 @section head { 
-    <link type="application/rss+xml" rel="alternate" title="Blog" href="/api/rss/" />
+    <link type="application/rss+xml" rel="alternate" title="Blog" href="/api/rss/" data-no-validate />
 }

--- a/input/community/speakers/_SpeakerLayout.cshtml
+++ b/input/community/speakers/_SpeakerLayout.cshtml
@@ -53,17 +53,17 @@
                         }
 
                         @{
-                            Dictionary<string, SpeakerLinkAttribute> speakerLinks = SpeakerLinkAttribute.GetAll();
-                            if (Document.ContainsAnyKeys(speakerLinks.Keys))
+                            KeyValuePair<string, SpeakerLinkAttribute>[] speakerLinks = SpeakerLinkAttribute.GetAll()
+                                .Where(x => !string.IsNullOrEmpty(x.Value.IconClass) && Document.ContainsKey(x.Key))
+                                .OrderBy(x => x.Key)
+                                .ToArray();
+                            if (speakerLinks.Length > 0)
                             {
                                 <div>
                                     <h3>Connect</h3>
-                                    @foreach (KeyValuePair<string, SpeakerLinkAttribute> speakerLink in speakerLinks.OrderBy(x => x.Key))
+                                    @foreach (KeyValuePair<string, SpeakerLinkAttribute> speakerLink in speakerLinks)
                                     {
-                                        if (Document.ContainsKey(speakerLink.Key))
-                                        {
-                                            <div><a href="@Document.GetString(speakerLink.Key)"><i class="@speakerLink.Value.IconClass"></i> @speakerLink.Key</a></div>
-                                        }
+                                        <div><a href="@Document.GetString(speakerLink.Key)"><i class="@speakerLink.Value.IconClass"></i> @speakerLink.Key</a></div>
                                     }
                                 </div>
                             }

--- a/input/community/speakers/aaron-powell.md
+++ b/input/community/speakers/aaron-powell.md
@@ -2,7 +2,7 @@ Title: Aaron Powell
 Twitter: https://twitter.com/slace
 Blog: https://www.aaron-powell.com
 Feed: https://www.aaron-powell.com/index.xml
-GitHub: http://github.com/aaronpowell
+GitHub: https://github.com/aaronpowell
 StackOverflow: https://stackoverflow.com/users/11388/aaron-powell
 LinkedIn: https://www.linkedin.com/in/aaron-powell-66038631
 Twitch: https://www.twitch.tv/NumberOneAaron/

--- a/input/community/speakers/add/index.cshtml
+++ b/input/community/speakers/add/index.cshtml
@@ -81,7 +81,7 @@
                                 <label class="font-weight-bold" for="feed">Blog RSS Feed</label>
                             </div>
                         </div>
-                        @foreach (string speakerLinkKey in SpeakerLinkAttribute.GetAll().Keys)
+                        @foreach (string speakerLinkKey in SpeakerLinkAttribute.GetAll().Where(x => x.Value.DisplayOnAddPage).Select(x => x.Key))
                         {
                             <div class="row mb-3">
                                 <div class="col">


### PR DESCRIPTION
This PR:
- Updates Statiq Web to the latest version.
- Refactors analyzers as a result of the update (there were a handful of breaking changes in the new analyzer feature).
- Adds a flag to trigger HTTPS validation for speaker links for sites we know support it.
- Adds the speaker blog link to the left-hand connect section on the speaker profile page.

Resolves #505.