### PR TITLE
Use Flexbox For Tags

### DIFF
--- a/input/css/style.css
+++ b/input/css/style.css
@@ -1596,7 +1596,14 @@ p.profile-company {
 }
 
 .profile-details {
+  justify-content: center;
+  flex-wrap: wrap;
+  display: flex;  
   padding-bottom: 0.5rem;
+}
+
+.profile-details .pr-2 {
+    padding: .15em;
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
The spacing on the profile details made was not pleasant to look at.
Fixed it with some flexbox.

## Before

![image](https://user-images.githubusercontent.com/228256/96304351-f2b93800-0fc9-11eb-9537-cc4ab501d12e.png)

## After

<img width="742" alt="Screenshot 2020-10-16 at 16 06 37@2x" src="https://user-images.githubusercontent.com/228256/96304377-fe0c6380-0fc9-11eb-8356-7538585c5a55.png">
