### PR TITLE
Speaker index improvements

### DIFF
--- a/input/_partials/_head.cshtml
+++ b/input/_partials/_head.cshtml
@@ -26,7 +26,7 @@
   <link rel="canonical" href="@Document.GetLink(true)" data-no-mirror>
   <link href="https://fonts.googleapis.com/css?family=Bree+Serif" rel="stylesheet" data-no-mirror=data-no-mirror />
   <link href="https://fonts.googleapis.com/css?family=Lato:300,400,700" rel="stylesheet" data-no-mirror=data-no-mirror />
-  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" data-no-mirror=data-no-mirror />
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" data-no-mirror=data-no-mirror />
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous" data-no-mirror=data-no-mirror />
   <link href="css/style.css" rel="stylesheet" />
   <link href="css/home.css" rel="stylesheet" />

--- a/input/community/speakers/add/index.cshtml
+++ b/input/community/speakers/add/index.cshtml
@@ -124,6 +124,15 @@
                     <div>
                         <button class="btn btn-lg btn-primary" type="submit">Submit</button>
                     </div>
+
+                    <div class="alert alert-dark mt-4" role="alert">
+                        <h4 class="alert-heading">Submission Process</h4>
+                        <p>
+                            When you click "Submit" above, a <a href="https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-requests">pull request will be created on GitHub</a>.
+                            Part of this process is to <a href="https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork">create a "fork"</a> of the repository
+                            that contains the code for the .NET Foundation website. GitHub will walk you through this process, but you may need to allow it to create a fork under your account and open the pull request from there.
+                        </p>
+                    </div>
                 </form>
             </div>
         </div>

--- a/input/community/speakers/index.cshtml
+++ b/input/community/speakers/index.cshtml
@@ -66,41 +66,50 @@ Title: Speaker Directory
                 </ul>
                 <div class="tab-content" id="tab-content">
                     <div class="tab-pane" id="tab-list" role="tabpanel" aria-labelledby="list-tab">
-                        <div class="row list">
+                        <div class="row row-cols-1 row-cols-sm-2 row-cols-md-4 list">
                             @foreach (IDocument speaker in OutputPages["community/speakers/*.html"].Where(x => !x.IdEquals(Document)))
                             {
-                            <div class="col-sm-6 col-md-4 profile list__item">
-                                <img img height="120" class="rounded-image profile-image" src="@speaker.GetString(SiteKeys.Image)" alt="@speaker.GetTitle()" />
+                                <div class="col mb-4 list__item">
+                                    <div class="card h-100 border-0 bg-light">
+                                        <div class="card-body text-center">
+                                            <img img height="80" class="rounded-image profile-image" src="@speaker.GetString(SiteKeys.Image)" alt="@speaker.GetTitle()" />
 
-                                <h3 class="profile-name"><a href="@Context.GetLink(speaker)" class="speakername">@speaker.GetTitle()</a></h3>
-                                <div class="d-none speakerlink">@Context.GetLink(speaker)</div>
+                                            <h3 class="profile-name"><a href="@Context.GetLink(speaker)" class="speakername">@speaker.GetTitle()</a></h3>
+                                            <div class="d-none speakerlink">@Context.GetLink(speaker)</div>
 
-                                @if (speaker.ContainsKey(SiteKeys.Location))
-                                {
-                                    <div class="profile-details font-weight-bold speakerlocation">@speaker.GetString(SiteKeys.Location)</div>
-                                }
-                                @if (speaker.ContainsKeys(SiteKeys.Lat, SiteKeys.Lon))
-                                {
-                                    <div class="d-none speakerlat">@speaker.GetString(SiteKeys.Lat)</div>
-                                    <div class="d-none speakerlon">@speaker.GetString(SiteKeys.Lon)</div>
-                                }
-                                @if (speaker.ContainsKey(SiteKeys.Language))
-                                {
-                                    <div class="d-none speakerlanguage">@speaker.GetString(SiteKeys.Language)</div>
-                                }
+                                            @if (speaker.ContainsKey(SiteKeys.Location))
+                                            {
+                                                <div class="profile-details font-weight-bold speakerlocation">@speaker.GetString(SiteKeys.Location)</div>
+                                            }
+                                            @if (speaker.ContainsKeys(SiteKeys.Lat, SiteKeys.Lon))
+                                            {
+                                                <div class="d-none speakerlat">@speaker.GetString(SiteKeys.Lat)</div>
+                                                <div class="d-none speakerlon">@speaker.GetString(SiteKeys.Lon)</div>
+                                            }
+                                            @if (speaker.ContainsKey(SiteKeys.Language))
+                                            {
+                                                <div class="d-none speakerlanguage">@speaker.GetString(SiteKeys.Language)</div>
+                                            }
 
-                                @if (speaker.ContainsKey(SiteKeys.Topics))
-                                {
-                                    <div class="profile-details">
-                                        @foreach (string topic in speaker.GetList<string>(SiteKeys.Topics))
-                                        {
-                                            <span class="pr-2"><a href="javascript:void(0)" class="filter btn btn-dark" data-filter="@topic">@topic</a></span>
-                                        }
+                                            @if (speaker.ContainsKey(SiteKeys.Topics))
+                                            {
+                                                string collapseName = $"collapse-{(speaker.GetTitle().ToLower().Replace(" ", "-"))}";
+                                                <a data-toggle="collapse" href="#@collapseName" role="button" aria-expanded="false" aria-controls="@collapseName">
+                                                    Show Topics
+                                                </a>
+                                                <div class="collapse profile-details" id="@collapseName">
+                                                    @foreach (string topic in speaker.GetList<string>(SiteKeys.Topics))
+                                                    {
+                                                        <span class="pr-2"><a href="javascript:void(0)" class="filter btn btn-sm btn-dark" data-filter="@topic">@topic</a></span>
+                                                    }
+                                                </div>
+                                            }
+
+                                            @* Includes other "topics" like language in this list *@
+                                            <div class="d-none speakertopics">@string.Join("|", speaker.GetList<string>(SiteKeys.Topics, Array.Empty<string>()).Concat(speaker.GetList<string>(SiteKeys.Language, Array.Empty<string>())))</div>
+                                        </div>
                                     </div>
-                                    @* Includes other "topics" like language in this list *@
-                                    <div class="d-none speakertopics">@string.Join("|", speaker.GetList<string>(SiteKeys.Topics).Concat(speaker.GetList<string>(SiteKeys.Language, Array.Empty<string>())))</div>
-                                }
-                            </div>
+                                </div>
                             }
                         </div>
                     </div>


### PR DESCRIPTION
This PR improves the speaker index layout by making the images a little smaller, hiding the speaker topics under a collapse, and changing the display to use equal-height cards:

![2020-10-19_10h25_34](https://user-images.githubusercontent.com/1020407/96465652-3349c900-11f7-11eb-80b0-4ed1b01c8e83.png)

I played around with 6 cards across, but that felt a little too squished. Also note part of this required updating Bootstrap to the latest (the number-of-cards-per-row class was only recently introduced). I spot checked the rest of the site to make sure the update didn't break anything, but keep an eye out for any oddness and I'll look into it.

I also snuck in some additional process notes on the add speaker page:

![2020-10-19_10h36_05](https://user-images.githubusercontent.com/1020407/96465751-4fe60100-11f7-11eb-80a4-3d4648b78cb1.png)

Resolves #523 and #541.

cc @clairernovotny and @shawnwildermuth - please review and merge when you get the chance.