### PR TITLE
Allow www prefix in submitted speaker URLs

### DIFF
--- a/SiteKeys.cs
+++ b/SiteKeys.cs
@@ -27,7 +27,7 @@
         [SpeakerLink("fab fa-stack-overflow", true, true, "https://stackoverflow.com/users/[yourUserId]/[yourUsername]", "[Hh][Tt][Tt][Pp][Ss]:\\/\\/[Ss][Tt][Aa][Cc][Kk][Oo][Vv][Ee][Rr][Ff][Ll][Oo][Ww]\\.[Cc][Oo][Mm]\\/[Uu][Ss][Ee][Rr][Ss]\\/\\d+\\/.*")]
         public const string StackOverflow = nameof(StackOverflow);
         // Regex pattern test: https://regex101.com/r/IlrLEM/1
-        [SpeakerLink("fab fa-linkedin", true, true, "https://linkedin.com/in/[yourUsername]", "[Hh][Tt][Tt][Pp][Ss]:\\/\\/[Ll][Ii][Nn][Kk][Ee][Dd][Ii][Nn]\\.[Cc][Oo][Mm]\\/[Ii][Nn]\\/.*")]
+        [SpeakerLink("fab fa-linkedin", true, true, "https://linkedin.com/in/[yourUsername]", "[Hh][Tt][Tt][Pp][Ss]:\\/\\/([Ww][Ww][Ww].)?[Ll][Ii][Nn][Kk][Ee][Dd][Ii][Nn]\\.[Cc][Oo][Mm]\\/[Ii][Nn]\\/.*")]
         public const string LinkedIn = nameof(LinkedIn);
         // Regex pattern test: https://regex101.com/r/D1Kxdu/1
         [SpeakerLink("fab fa-twitch", true, true, "https://twitch.tv/[yourUsername]", "[Hh][Tt][Tt][Pp][Ss]:\\/\\/[Tt][Ww][Ii][Tt][Cc][Hh]\\.[Tt][Vv]\\/.*")]

--- a/SiteKeys.cs
+++ b/SiteKeys.cs
@@ -24,7 +24,7 @@
         [SpeakerLink("fab fa-github", true, true, "https://github.com/[yourUsername]", "[Hh][Tt][Tt][Pp][Ss]:\\/\\/([Ww][Ww][Ww].)?[Gg][Ii][Tt][Hh][Uu][Bb]\\.[Cc][Oo][Mm]\\/.*")]
         public const string GitHub = nameof(GitHub);
         // Regex pattern test: https://regex101.com/r/0OHcSZ/1
-        [SpeakerLink("fab fa-stack-overflow", true, true, "https://stackoverflow.com/users/[yourUserId]/[yourUsername]", "[Hh][Tt][Tt][Pp][Ss]:\\/\\/[Ss][Tt][Aa][Cc][Kk][Oo][Vv][Ee][Rr][Ff][Ll][Oo][Ww]\\.[Cc][Oo][Mm]\\/[Uu][Ss][Ee][Rr][Ss]\\/\\d+\\/.*")]
+        [SpeakerLink("fab fa-stack-overflow", true, true, "https://stackoverflow.com/users/[yourUserId]/[yourUsername]", "[Hh][Tt][Tt][Pp][Ss]:\\/\\/([Ww][Ww][Ww].)?[Ss][Tt][Aa][Cc][Kk][Oo][Vv][Ee][Rr][Ff][Ll][Oo][Ww]\\.[Cc][Oo][Mm]\\/[Uu][Ss][Ee][Rr][Ss]\\/\\d+\\/.*")]
         public const string StackOverflow = nameof(StackOverflow);
         // Regex pattern test: https://regex101.com/r/IlrLEM/1
         [SpeakerLink("fab fa-linkedin", true, true, "https://linkedin.com/in/[yourUsername]", "[Hh][Tt][Tt][Pp][Ss]:\\/\\/([Ww][Ww][Ww].)?[Ll][Ii][Nn][Kk][Ee][Dd][Ii][Nn]\\.[Cc][Oo][Mm]\\/[Ii][Nn]\\/.*")]

--- a/SiteKeys.cs
+++ b/SiteKeys.cs
@@ -30,7 +30,7 @@
         [SpeakerLink("fab fa-linkedin", true, true, "https://linkedin.com/in/[yourUsername]", "[Hh][Tt][Tt][Pp][Ss]:\\/\\/([Ww][Ww][Ww].)?[Ll][Ii][Nn][Kk][Ee][Dd][Ii][Nn]\\.[Cc][Oo][Mm]\\/[Ii][Nn]\\/.*")]
         public const string LinkedIn = nameof(LinkedIn);
         // Regex pattern test: https://regex101.com/r/D1Kxdu/1
-        [SpeakerLink("fab fa-twitch", true, true, "https://twitch.tv/[yourUsername]", "[Hh][Tt][Tt][Pp][Ss]:\\/\\/[Tt][Ww][Ii][Tt][Cc][Hh]\\.[Tt][Vv]\\/.*")]
+        [SpeakerLink("fab fa-twitch", true, true, "https://twitch.tv/[yourUsername]", "[Hh][Tt][Tt][Pp][Ss]:\\/\\/([Ww][Ww][Ww].)?[Tt][Ww][Ii][Tt][Cc][Hh]\\.[Tt][Vv]\\/.*")]
         public const string Twitch = nameof(Twitch);
         [SpeakerLink("fas fa-bullhorn", true, true, "https://sessionize.com/[yourUsername]")]
         public const string Sessionize = nameof(Sessionize);

--- a/SiteKeys.cs
+++ b/SiteKeys.cs
@@ -18,10 +18,10 @@
         [SpeakerLink(null, false, false)]
         public const string Feed = nameof(Feed);
         // Regex pattern test: https://regex101.com/r/LsRovM/1
-        [SpeakerLink("fab fa-twitter", true, true, "https://twitter.com/[yourUsername]", "[Hh][Tt][Tt][Pp][Ss]:\\/\\/[Tt][Ww][Ii][Tt][Tt][Ee][Rr]\\.[Cc][Oo][Mm]\\/.*")]
+        [SpeakerLink("fab fa-twitter", true, true, "https://twitter.com/[yourUsername]", "[Hh][Tt][Tt][Pp][Ss]:\\/\\/([Ww][Ww][Ww].)?[Tt][Ww][Ii][Tt][Tt][Ee][Rr]\\.[Cc][Oo][Mm]\\/.*")]
         public const string Twitter = nameof(Twitter);
         // Regex pattern test: https://regex101.com/r/FICmFg/1
-        [SpeakerLink("fab fa-github", true, true, "https://github.com/[yourUsername]", "[Hh][Tt][Tt][Pp][Ss]:\\/\\/[Gg][Ii][Tt][Hh][Uu][Bb]\\.[Cc][Oo][Mm]\\/.*")]
+        [SpeakerLink("fab fa-github", true, true, "https://github.com/[yourUsername]", "[Hh][Tt][Tt][Pp][Ss]:\\/\\/([Ww][Ww][Ww].)?[Gg][Ii][Tt][Hh][Uu][Bb]\\.[Cc][Oo][Mm]\\/.*")]
         public const string GitHub = nameof(GitHub);
         // Regex pattern test: https://regex101.com/r/0OHcSZ/1
         [SpeakerLink("fab fa-stack-overflow", true, true, "https://stackoverflow.com/users/[yourUserId]/[yourUsername]", "[Hh][Tt][Tt][Pp][Ss]:\\/\\/[Ss][Tt][Aa][Cc][Kk][Oo][Vv][Ee][Rr][Ff][Ll][Oo][Ww]\\.[Cc][Oo][Mm]\\/[Uu][Ss][Ee][Rr][Ss]\\/\\d+\\/.*")]


### PR DESCRIPTION
Resolves #594. Even though the URL is specified in a given format, we want to allow for `www`, as that's a common / natural prefix.

Follow-up to #554 where I missed this case. Sorry!

## Updated Regex Test cases

* Twitter: https://regex101.com/r/LsRovM/2
* GitHub: https://regex101.com/r/FICmFg/2
* LinkedIn: https://regex101.com/r/IlrLEM/2
* Twitch: https://regex101.com/r/D1Kxdu/2
* StackOverflow: https://regex101.com/r/0OHcSZ/2