### PR TITLE
Fix speaker topics not expanding/collapsing when speaker name contains a "." (dot)

### DIFF
--- a/input/community/speakers/index.cshtml
+++ b/input/community/speakers/index.cshtml
@@ -93,7 +93,7 @@ Title: Speaker Directory
 
                                             @if (speaker.ContainsKey(SiteKeys.Topics))
                                             {
-                                                string collapseName = $"collapse-{(speaker.GetTitle().ToLower().Replace(" ", "-"))}";
+                                                string collapseName = $"collapse-{(speaker.GetTitle().ToLower().Replace(" ", "-").Replace(".", "-"))}";
                                                 <a data-toggle="collapse" href="#@collapseName" role="button" aria-expanded="false" aria-controls="@collapseName">
                                                     Show Topics
                                                 </a>


### PR DESCRIPTION
When the speaker name has a "." (dot), expanding & collapsing the topics doesn't work.
