### PR TITLE
Adds preferred gender pronouns to the speaker directory

### DIFF
--- a/Analyzers/ValidateSpeakerLanguage.cs
+++ b/Analyzers/ValidateSpeakerLanguage.cs
@@ -1,0 +1,24 @@
+﻿using Statiq.Common;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DotnetFoundationWeb
+{
+    public class ValidateSpeakerLanguage : SpeakerDataAnalyzer
+    {
+        protected override void AnalyzeSpeakerData(IDocument document, IAnalyzerContext context)
+        {
+            IReadOnlyList<string> languages = document.GetList<string>(SiteKeys.Language);
+            if (languages?.Count > 0)
+            {
+                foreach (string language in languages)
+                {
+                    if (!char.IsUpper(language[0]))
+                    {
+                        context.AddAnalyzerResult(document, $"Please capitalize speaker language: {language}");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Analyzers/ValidateSpeakerPronouns.cs
+++ b/Analyzers/ValidateSpeakerPronouns.cs
@@ -1,0 +1,17 @@
+﻿using Statiq.Common;
+using System.Linq;
+
+namespace DotnetFoundationWeb
+{
+    public class ValidateSpeakerPronouns : SpeakerDataAnalyzer
+    {
+        protected override void AnalyzeSpeakerData(IDocument document, IAnalyzerContext context)
+        {
+            string pronouns = document.GetString(SiteKeys.Pronouns);
+            if (!pronouns.IsNullOrEmpty() && (pronouns.Count(x => x == '/') != 1 || pronouns.Any(x => x != '/' && (!char.IsLetter(x) || !char.IsLower(x)))))
+            {
+                context.AddAnalyzerResult(document, $"Preferred gender pronouns should be of the form [subject]/[object] in lowercase (I.e. \"they/them\")");
+            }
+        }
+    }
+}

--- a/SiteKeys.cs
+++ b/SiteKeys.cs
@@ -9,6 +9,7 @@
         public const string AzureMapsSubscriptionKey = nameof(AzureMapsSubscriptionKey);
 
         // Speakers
+        public const string Pronouns = nameof(Pronouns); // [subject]/[object] (I.e. "they/them")
         public const string Location = nameof(Location);  // Plain language location name
         public const string Lat = nameof(Lat);  // Fetched based on Location, but can be explicitly provided
         public const string Lon = nameof(Lon);  // Fetched based on Location, but can be explicitly provided

--- a/input/community/speakers/_SpeakerLayout.cshtml
+++ b/input/community/speakers/_SpeakerLayout.cshtml
@@ -72,7 +72,13 @@
                         }
                     </div>
                     <div class="col-md-9 p-5">
-                        <h1>@Document.GetTitle()</h1>
+                        <h1>
+                            @Document.GetTitle()
+                            @if (Document.ContainsKey(SiteKeys.Pronouns))
+                            {
+                                <small class="text-muted">(@Document.GetString(SiteKeys.Pronouns))</small>
+                            }
+                        </h1>
                         @RenderBody()
 
                         @if (Document.ContainsKey(SiteKeys.BlogFeedItems))

--- a/input/community/speakers/add/index.cshtml
+++ b/input/community/speakers/add/index.cshtml
@@ -21,6 +21,12 @@
                     </div>
 
                     <div class="form-group">
+                        <label for="pronouns" class="mb-0 font-weight-bold">Preferred Gender Pronouns</label>
+                        <small id="pronouns-help" class="form-text text-muted mb-3">Your preferred gender pronouns of the form [subject]/[object] (I.e. "they/them").</small>
+                        <input id="pronouns" class="form-control" aria-describedby="pronouns-help">
+                    </div>
+
+                    <div class="form-group">
                         <label for="location" class="mb-0 font-weight-bold">Location</label>
                         <small id="location-help" class="form-text text-muted mb-3">Your location in plain language (for example, "Seattle, Washington USA").</small>
                         <input id="location" class="form-control" aria-describedby="location-help">
@@ -159,6 +165,11 @@
                 return;
             }
             let content = "---\nTitle: " + fullname.trim() + "\n";
+
+            let pronouns = $("#pronouns").val();
+            if (pronouns) {
+                content += "Pronouns: " + pronouns.trim() + "\n";
+            }
 
             let location = $("#location").val();
             if (location) {


### PR DESCRIPTION
This PR adds support for specifying and displaying preferred speaker pronouns to speakers in the speaker directory.

Here's what it looks like on the speaker submission page:

![image](https://user-images.githubusercontent.com/1020407/102499303-ff4d2180-4048-11eb-90b6-dede33f8f2a5.png)

And here's how it shows on a speaker profile if specified:

![image](https://user-images.githubusercontent.com/1020407/102499359-10962e00-4049-11eb-8411-5d0faf3dc0d8.png)

An analyzer is also added to validate the pronoun formatting so they're consistent (but we don't validate the actual pronouns).

As a bonus I also added an analyzer to validate language capitalization (see #689)