### PR TITLE
Add visual indicator of asc/desc order when sorting speakers by name/location

### DIFF
--- a/input/css/style.css
+++ b/input/css/style.css
@@ -1861,3 +1861,13 @@ table thead td {
     padding: 3rem !important;
   }
 }
+
+.sort.asc::after {
+  content: "\002B06";
+  padding-left: 3px;
+}
+
+.sort.desc::after {
+  content: "\002B07";
+  padding-left: 3px;
+}


### PR DESCRIPTION
### Before this PR

![2020-12-29_11-03-56 (1)](https://user-images.githubusercontent.com/177608/103293746-d6247d80-49c6-11eb-9a82-a20670f07b00.gif)

---

### After this PR

![2020-12-29_11-06-02 (1)](https://user-images.githubusercontent.com/177608/103293753-da509b00-49c6-11eb-871c-02196cf5296a.gif)
