### PR TITLE
Blurs the speaker filters on click

### DIFF
--- a/input/community/speakers/index.cshtml
+++ b/input/community/speakers/index.cshtml
@@ -49,7 +49,7 @@ Title: Speaker Directory
                         <div class="col-sm-10" id="topic-filters">
                             @foreach (string topic in fromSpeakers(SiteKeys.Topics))
                             {
-                                <a class="filter btn btn-light mb-2" href="javascript:void(0)" data-filter="@topic">@topic</a>
+                                <a class="filter btn btn-light mb-2" href="javascript:void(0)" onclick="blur(this)" data-filter="@topic">@topic</a>
                             }
                         </div>
                     </div>
@@ -58,7 +58,7 @@ Title: Speaker Directory
                         <div class="col-sm-10" id="language-filters">
                             @foreach (string language in fromSpeakers(SiteKeys.Language))
                             {
-                                <a class="filter btn btn-light mb-2" href="javascript:void(0)" data-filter="@language">@language</a>
+                                <a class="filter btn btn-light mb-2" href="javascript:void(0)" onclick="blur(this)" data-filter="@language">@language</a>
                             }
                         </div>
                     </div>
@@ -110,7 +110,7 @@ Title: Speaker Directory
                                                 <div class="collapse profile-details" id="@collapseName">
                                                     @foreach (string topic in speaker.GetList<string>(SiteKeys.Topics))
                                                     {
-                                                        <span class="pr-2"><a href="javascript:void(0)" class="filter btn btn-sm btn-dark" data-filter="@topic">@topic</a></span>
+                                                        <span class="pr-2"><a href="javascript:void(0)" onclick="blur(this)" class="filter btn btn-sm btn-dark" data-filter="@topic">@topic</a></span>
                                                     }
                                                 </div>
                                             }


### PR DESCRIPTION
This blurs the filter buttons in the speaker directory when they're clicked (seemed better to me than changing the default Bootstrap styles).

Resolves #759

cc @MaximRouiller