### PR TITLE
Fix speaker page topic filter

### DIFF
--- a/input/community/speakers/index.cshtml
+++ b/input/community/speakers/index.cshtml
@@ -153,11 +153,11 @@ Title: Speaker Directory
         speakers.filter(function (item) {
           let itemTopics = [ htmlDecode(item.values().speakertopics) ];
             if (item.values().speakertopics.indexOf('|') > 0) {
-                itemTopics = htmlDecode(item.values().speakertopics).split('|');
+                itemTopics = htmlDecode(item.values().speakertopics).toLowerCase().split('|');
             }
             var include = true;
             $('.filter.active').each(function (index, filter) {
-                if (!itemTopics.includes($(filter).data('filter'))) {
+                if (!itemTopics.includes($(filter).data('filter').toLowerCase())) {
                     include = false;
                 }
             });


### PR DESCRIPTION
Right now, topic filter on the speaker page is broken for `NuGet`, `JavaScript`, `SignalR`, ... Essentially any topic with mixed case :)

This PR does the filtering based on lowercase values to make sure topics and selected topics always match.