### PR TITLE
Add the C# Standard project

### DIFF
--- a/input/projects/data/csharp-standard.md
+++ b/input/projects/data/csharp-standard.md
@@ -1,0 +1,27 @@
+---
+Title: C# Standard
+Contributor: Ecma International
+Web: https://www.ecma-international.org/
+---
+# C# language standard
+
+[TC49-TG2](https://www.ecma-international.org/task-groups/tc49-tg2/) writes the official C# standard. The scope is to standardize the syntax and semantics of a modern, component-based, general purpose, object oriented, and type-safe programming language called C# (pronounced C sharp).
+
+The committee Programme of work:
+
+1. Develop C# language standards.
+1. Upon completion of item 1, to investigate the future direction of C# standards, and to evaluate and consider proposals for complementary or additional technology.
+1. To establish and maintain liaison with other Ecma TCs and with other Standards Development Organisations (SDOs) as appropriate to facilitate and promulgate the work of the TG.
+
+**Important**: This committee does not propose enhancements to the language. Its purpose is to produce the standard based on the reference implementation from the [Roslyn project](https://github.com/dotnet/roslyn).
+
+# Project Details
+
+* [Project Info Site](https://www.ecma-international.org/task-groups/tc49-tg2/)
+* [Project Source Site](https://github.com/dotnet/csharpstandard)
+* Committee convenor: [Jon Skeet](https://github.com/jskeet)
+
+### Quicklinks
+
+* [Documentation](https://docs.microsoft.com/dotnet/csharp/language-reference/language-specification/introduction)
+* [Discussions](https://github.com/dotnet/csharpstandard/issues)

--- a/input/projects/data/csharp-standard.md
+++ b/input/projects/data/csharp-standard.md
@@ -7,7 +7,7 @@ Web: https://www.ecma-international.org/
 
 [TC49-TG2](https://www.ecma-international.org/task-groups/tc49-tg2/) writes the official C# standard. The scope is to standardize the syntax and semantics of a modern, component-based, general purpose, object oriented, and type-safe programming language called C# (pronounced C sharp).
 
-The committee Programme of work:
+The committee programme of work:
 
 1. Develop C# language standards.
 1. Upon completion of item 1, to investigate the future direction of C# standards, and to evaluate and consider proposals for complementary or additional technology.
@@ -24,4 +24,5 @@ The committee Programme of work:
 ### Quicklinks
 
 * [Documentation](https://docs.microsoft.com/dotnet/csharp/language-reference/language-specification/introduction)
+* [Standard source text](https://github.com/dotnet/csharpstandard/tree/draft-v6/standard)
 * [Discussions](https://github.com/dotnet/csharpstandard/issues)


### PR DESCRIPTION
Add the description of the C# standardization work.

See dotnet-foundation/projects#90

I'd like both @madstorgersen and @jskeet to review for the correct language for ECMA before merging.