### PR TITLE
strengthen language on dues

### DIFF
--- a/input/member/become-a-member.cshtml
+++ b/input/member/become-a-member.cshtml
@@ -33,10 +33,10 @@ permalink: /become-a-member
                     </li>
                     <li>
                         Upon approval, members will be notified with information on completing their membership.
-                        We request members pay suggested $100 annual dues, with liberal waivers for students or financial hardship.
                         Individual member dues help support our operations and activities, but are voluntary - you can set your own amount, 
                         or opt-out entirely. We don't tie an individual's payment to his or her membership rights and privileges. We don't 
                         want dues to be an obstacle for anyone who is interested in getting involved.
+                        We request members pay suggested $100 annual dues.
                     </li>
                     <li>
                         Each year, we’ll host an election for the board of directors. Any active member can


### PR DESCRIPTION
Make it more clear that dues are a voluntary contribution to the foundation.

The nominating committee has requested that we state this position more strongly. They have expressed the dues being a barrier to attracting members and candidates from different geographical areas in the world.
