### PR TITLE
.NET Runtime link fixed

### DIFF
--- a/input/projects/data/netcore.md
+++ b/input/projects/data/netcore.md
@@ -15,7 +15,7 @@ Web: http://www.microsoft.com
 ## Project Details
 
 * [Project Info Site](https://github.com/dotnet/core)
-* Project Code Repos:  [.NET Core Framework](https://github.com/dotnet/corefx), [.NET Core Common Language Runtime]( https://github.com/dotnet/coreCLR), [.NET Core Tools](https://github.com/dotnet/cli)
+* Project Code Repos: [.NET Runtime](https://github.com/dotnet/runtime), [.NET Core Framework](https://github.com/dotnet/corefx), [.NET Core Tools](https://github.com/dotnet/cli)
 * Project Docs Repos: [Concepts](https://github.com/dotnet/docs), [APIs](https://github.com/dotnet/dotnet-api-docs), [Samples](https://github.com/dotnet/samples)
 * Project License Type: [MIT](https://github.com/dotnet/runtime/blob/master/LICENSE.TXT)
 * Project Main Contact: [Immo Landwerth](https://github.com/terrajobst)


### PR DESCRIPTION
I also want to fix the link "You can edit this page on Github", but I couldn't find it in the repo. The idea is to replace master with main, because now it returns a 404 because of the wrong branch name.