### PR TITLE
add contribution model to project submit page

### DIFF
--- a/input/projects/submit.cshtml
+++ b/input/projects/submit.cshtml
@@ -24,8 +24,9 @@ permalink: /projects/submit
               <p>When you are ready to apply to join, <a href="https://github.com/dotnet-foundation/projects/issues/new?assignees=&amp;labels=project+application&amp;template=application.md&amp;title=">fill out a new project application</a></p>
               <p>You can complete the application in GitHub directly, email us a copy of the document, or attach a copy of the document to the GitHub issue. To help with some of the common questions in the application or to provide clarification on certain items, we’ve
 	              included extra details to help you along.</p>
-                    <p><strong>Assignment Model.</strong> The .NET Foundation uses an assignment model for on-boarding new projects.  Under the assignment model, a project transfers ownership of the copyright to the .NET Foundation. The project also confirms
-	              that the project’s submissions to .NET Foundation are its own original work (there are also instructions for any third party materials that might be included).</p>
+                    <p><strong>Assignment and Contribution Models.</strong> The .NET Foundation uses either an assignment model or a contribution model for on-boarding new projects.  Under the assignment model, a project transfers ownership of the copyright to the .NET Foundation.
+					Under the contribution model, a project retains ownership of the project, but grants the .NET Foundation a broad license to the project’s code and other intellectual property.
+					The project also confirms that the project’s submissions to .NET Foundation are its own original work (there are also instructions for any third party materials that might be included).</p>
               <p><strong>Review Process.</strong> Once you’ve submitted the issue, it will be reviewed by the Project Review committee and they will follow up with any questions on your application. After the review is complete and it’s ready to move forward, the .NET
 	              Foundation Board will review it. The Board meets monthly and reviews new projects sent over from the Project Review committee. After the board votes to approve a new project, signing the CLA is up next.</p>
               <h2 id="signing-the-cla">Signing the CLA</h2>

--- a/input/projects/submit.cshtml
+++ b/input/projects/submit.cshtml
@@ -25,7 +25,7 @@ permalink: /projects/submit
               <p>You can complete the application in GitHub directly, email us a copy of the document, or attach a copy of the document to the GitHub issue. To help with some of the common questions in the application or to provide clarification on certain items, we’ve
 	              included extra details to help you along.</p>
                     <p><strong>Assignment and Contribution Models.</strong> The .NET Foundation uses either an assignment model or a contribution model for on-boarding new projects.  Under the assignment model, a project transfers ownership of the copyright to the .NET Foundation.
-					Under the contribution model, a project retains ownership of the project, but grants the .NET Foundation a broad license to the project’s code and other intellectual property.
+					Under the contribution model, a project retains ownership of the copyright, but grants the .NET Foundation a broad license to the project’s code and other intellectual property.
 					The project also confirms that the project’s submissions to .NET Foundation are its own original work (there are also instructions for any third party materials that might be included).</p>
               <p><strong>Review Process.</strong> Once you’ve submitted the issue, it will be reviewed by the Project Review committee and they will follow up with any questions on your application. After the review is complete and it’s ready to move forward, the .NET
 	              Foundation Board will review it. The Board meets monthly and reviews new projects sent over from the Project Review committee. After the board votes to approve a new project, signing the CLA is up next.</p>


### PR DESCRIPTION
This PR adds some language to the project submit page regarding the contribution model. It previously only mentioned the assignment model I think this has caused some confusion:

- https://github.com/dotnet-foundation/projects/issues/171
- https://github.com/dotnet-foundation/projects/issues/121

I noticed that the issue template for project submit did describe the contribution model so I added that language on the project submission page.

Thanks!