### PR TITLE
Updated Statiq.Web to 1.0.0-beta.33

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ TestResult.xml
 *.pfx
 projects-content.json
 .idea/
+/cache
 
 functions/node_modules/
 input/api/issues/index.js

--- a/Generator.csproj
+++ b/Generator.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.11.28" />
     <PackageReference Include="Microsoft.SyndicationFeed.ReaderWriter" Version="1.0.2" />
-    <PackageReference Include="Statiq.Web" Version="1.0.0-beta.9" />
+    <PackageReference Include="Statiq.Web" Version="1.0.0-beta.33" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
   </ItemGroup>
 

--- a/input/blog/_archives.cshtml
+++ b/input/blog/_archives.cshtml
@@ -15,7 +15,7 @@
                 .GroupBy(doc => (doc.GetDateTime(WebKeys.Published).ToString("MM"), doc.GetDateTime(WebKeys.Published).ToString("MMMM")))
                 .OrderByDescending(x => x.Key.Item1))
             {
-                <div><a href="blog/@(yearGroup.Key)/@(monthGroup.Key.Item1)">@monthGroup.Key.Item2 (@monthGroup.Count())</a></div>
+                <div><a href="/blog/@(yearGroup.Key)/@(monthGroup.Key.Item1)">@monthGroup.Key.Item2 (@monthGroup.Count())</a></div>
             }
             </div>
         }

--- a/input/blog/archive.cshtml
+++ b/input/blog/archive.cshtml
@@ -1,5 +1,5 @@
 ---
-Enumerate: => Inputs.FilterSources("blog/posts/*").Select(x => x.GetDateTime("Published").ToString("yyyy/MM")).Distinct()
+Enumerate: => Parent.Inputs.FilterSources("blog/posts/*").Select(x => x.GetDateTime("Published").ToString("yyyy/MM")).Distinct()
 DestinationPath: => new NormalizedPath($"blog/{GetString("Current")}/index.html")
 Title: => $"Post Archive - {GetString("Current")}"
 ---


### PR DESCRIPTION
This PR updates the version of Statiq Web used to 1.0.0-beta.33. It required minimal changes and I verified correctness using a diff between the old and the new version.