### PR TITLE
Adding project entries for ClangSharp and LLVMSharp

### DIFF
--- a/input/projects/data/clangsharp.md
+++ b/input/projects/data/clangsharp.md
@@ -1,0 +1,20 @@
+---
+Title: ClangSharp
+Contributor: Microsoft
+Web: https://github.com/dotnet/clangsharp
+---
+# ClangSharp
+
+[ClangSharp](https://github.com/dotnet/clangsharp) provides [Clang](https://clang.llvm.org/) bindings written in C#. It is self-hosted and auto-generates itself by parsing the Clang C header files using ClangSharpPInvokeGenerator.
+
+# Project Details
+
+- [Project Code Site](https://github.com/dotnet/clangsharp)
+- Project License Type: [MIT](https://github.com/dotnet/clangsharp/blob/main/LICENSE.md)
+
+### Quicklinks
+
+- [Building the Repo](https://github.com/dotnet/clangsharp#building-managed)
+- [Generating Bindings](https://github.com/dotnet/clangsharp#generating-bindings)
+- [Discussions](https://github.com/dotnet/clangsharp/discussions)
+- [Projects using ClangSharp](https://github.com/dotnet/clangsharp#spotlight)

--- a/input/projects/data/llvmsharp.md
+++ b/input/projects/data/llvmsharp.md
@@ -1,0 +1,18 @@
+---
+Title: LLVMSharp
+Contributor: Microsoft
+Web: https://github.com/dotnet/llvmsharp
+---
+# LLVMSharp
+
+[LLVMSharp](https://github.com/dotnet/llvmsharp) is a multi-platform .NET Standard library for accessing the LLVM infrastructure. The bindings are auto-generated using [ClangSharp](https://github.com/dotnet/clangsharp) parsing LLVM-C header files.
+
+# Project Details
+
+- [Project Code Site](https://github.com/dotnet/llvmsharp)
+- Project License Type: [MIT](https://github.com/dotnet/llvmsharp/blob/main/LICENSE.md)
+
+### Quicklinks
+
+- [Building the Repo](https://github.com/microsoft/llvmsharp#building-llvmsharp)
+- [Discussions](https://github.com/dotnet/llvmsharp/discussions)


### PR DESCRIPTION
As per https://github.com/dotnet-foundation/projects/issues/184.

CC. @ChrisSfanos, ~~LLVMSharp hasn't quite been moved over yet so the URL isn't correct yet.~~ LLVMSharp has been moved over now as well, this should be good to merge.