### PR TITLE
Fix incorrect repository URL for CoreWF

### DIFF
--- a/input/projects/data/corewf.md
+++ b/input/projects/data/corewf.md
@@ -1,21 +1,21 @@
 ---
 Title: CoreWF
-Contributor: UIPath
+Contributor: UiPath
 Logo: dotnet-platform.png
-Web: https://github.com/UiPath-Open/corewf
+Web: https://github.com/UiPath/CoreWF
 ---
 # CoreWF
 
-[CoreWF](https://github.com/UiPath-Open/corewf) is a port of the Windows Workflow Foundation (WF) runtime to .NET Core and .NET Standard.
+[CoreWF](https://github.com/UiPath/CoreWF) is a port of the Windows Workflow Foundation (WF) runtime to .NET Core and .NET Standard.
 
 ## Project Details
 
-* [Project Info Site](https://github.com/UiPath-Open/corewf)
-* [Project Code Site](https://github.com/UiPath-Open/corewf)
-* Project License Type: [MIT](https://github.com/UiPath-Open/corewf/blob/master/LICENSE)
+* [Project Info Site](https://github.com/UiPath/CoreWF)
+* [Project Code Site](https://github.com/UiPath/CoreWF)
+* Project License Type: [MIT](https://github.com/UiPath/CoreWF/blob/master/LICENSE)
 * Project Main Contacts: [Lucian Bargaoanu](https://github.com/lbargaoanu) and [Dustin Metzgar](https://github.com/dmetzgar).
 
 ## Quicklinks
 
-* [Documentation](https://github.com/UiPath-Open/corewf/blob/master/LICENSE)
-* [Contribute](https://github.com/UiPath-Open/corewf/blob/master/CONTRIBUTING.md)
+* [Documentation](https://github.com/UiPath/CoreWF/blob/master/LICENSE)
+* [Contribute](https://github.com/UiPath/CoreWF/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
Not sure if the repository URL was wrong to begin with or if the repo was moved in the meantime, but as of now it is pointing to a dummy repository with some takeover message. This PR updates all the links to point to the proper repo URL (https://github.com/UiPath/CoreWF).