### PR TITLE
Project benefits content

### DIFF
--- a/input/projects/why-join-wip.md
+++ b/input/projects/why-join-wip.md
@@ -23,6 +23,11 @@ Legal can be tricky. We can help. Projects in our organization will get:
 
 The more people who know about .NET, the better for the ecosystem. We work with Amazon, JetBrains, Microsoft, Progress, and other industry leaders to improve your project's exposure within the community at large. Your success is our success - we'd love to see you achieve the accolades you deserve!
 
+The .NET Foundation helps any .NET project that reaches out to it with marketing advice or promotion via social media. Additionally, the .NET Foundation helps produce videos about member projects and maintainers:
+
+* [.NET Foundation Project Spotlight](https://www.youtube.com/playlist?list=PL1rZQsJPBU2Ql5ZBOOdqn32xPMEUdor5Z)
+* [Maintainer Series](https://www.youtube.com/playlist?list=PL1rZQsJPBU2TA8lm-2S0TMdT5FlL1sxuF)
+
 ## CLA management
 
 A Contributor License Agreement (CLA) ensures a project has the necessary rights to code contributions.


### PR DESCRIPTION
I think the current project benefits page - https://dotnetfoundation.org/projects/why-join - can be improved.

This PR:
* Adds a couple of sentences that summarize the goal of benefits (improve governance, maturity, stability) and non-goals (replacing maintainers and contributors)
* Changes list of benefits to a flat list. The current page groups benefits into administrative and technical. This seems unnecessary and distracts from the benefits themselves
* Clarifies why a couple of benefits are useful. e.g. why a CLA is good, why code signing is beneficial. Probably more could be done here

Something else to do now could be to remove benefits that aren't valid anymore (is offering Azure Dev Ops for CI useful now that GitHub has actions?) and add new ones.

The PR is currently markdown to focus on the content. If the content is eventually approved then it can be adapted to cshtml.