### PR TITLE
Remove BLM banner so we only have one at a time.

### DIFF
--- a/input/_partials/_header.cshtml
+++ b/input/_partials/_header.cshtml
@@ -21,11 +21,13 @@
     </section>
     -->
 
+  <!--
     <section class="flash justify-content-center align-items-center" style="background-color: #000000;font-weight:bold">
         <div class="alert show w-100 text-center" role="alert">
             Black Lives Matter. <u><a style="color:#bb9d86" target="_blank" rel="noreferrer" href="https://support.eji.org/give/153413/#!/donation/checkout">Support the Equal Justice Initiative.</a></u>
         </div>
     </section>
+  -->
 
     <section class="flash justify-content-center align-items-center" style="background-color: #005BBB;font-weight:bold">
         <div class="alert show w-100 text-center" role="alert">
@@ -105,7 +107,7 @@
                   <div class="dropdown-menu" aria-labelledby="education-dropdown">
                     <a class="dropdown-item" href="https://github.com/dotnet-foundation/wg-education">Education Committee</a>
                     <a class="dropdown-item" href="/education/academy">.NET Foundation Academy</a>
-                    
+
                   </div>
                   <div class="mobile-items" aria-labelledby="education-dropdown--mobile">
                     <a class="dropdown-item" href="/education">Education</a>


### PR DESCRIPTION
It was decided that we should only have one banner on the website at a time. This is in no way an indication of our feelings towards BLM, only that we feel that the Ukrainian crisis needs highlighting right now.