### PR TITLE
Added .NET MAUI as a speaker topic

### DIFF
--- a/Analyzers/ValidateSpeakerTopics.cs
+++ b/Analyzers/ValidateSpeakerTopics.cs
@@ -35,6 +35,7 @@ namespace DotnetFoundationWeb
             "JetBrains Rider",
             "Machine Learning",
             "macOS",
+            "MAUI",
             "Microsoft 365",
             "Microsoft Graph",
             "Microsoft Teams",


### PR DESCRIPTION
I'm just wondering that the correct name is ".NET MAUI" or simply "MAUI"