### PR TITLE
Remove link to store until there is an active store

### DIFF
--- a/input/_partials/_header.cshtml
+++ b/input/_partials/_header.cshtml
@@ -88,7 +88,6 @@
                     <a class="dropdown-item" href="/community/speakers">Speakers</a>
                     <a class="dropdown-item" href="/community/get-involved">Get Involved</a>
                     <a class="dropdown-item" href="/community/resources">Resources</a>
-                    <a class="dropdown-item" href="https://store.dotnetfoundation.org">Store</a>
                   </div>
                   <div class="mobile-items" aria-labelledby="community-dropdown--mobile">
                       <a class="dropdown-item" href="/community">Community</a>
@@ -97,7 +96,6 @@
                       <a class="dropdown-item" href="/community/speakers">Speakers</a>
                       <a class="dropdown-item" href="/community/get-involved">Get Involved</a>
                       <a class="dropdown-item" href="/community/resources">Resources</a>
-                      <a class="dropdown-item" href="https://store.dotnetfoundation.org">Store</a>
                   </div>
                 </li>
                 <li class="nav-item dropdown main-menu_item">


### PR DESCRIPTION
https://store.dotnetfoundation.org is offline and users are reporting cert errors. Recommend removing the link until there is an active store.