### PR TITLE
Add link to New Site in Banner

### DIFF
--- a/input/_partials/_header.cshtml
+++ b/input/_partials/_header.cshtml
@@ -35,6 +35,12 @@
         </div>
     </section>
 
+    <section class="flash justify-content-center align-items-center" style="background-color: ##68217a;font-weight:bold">
+        <div class="alert show w-100 text-center" role="alert">
+            This is the old version of the .NET Foundation Website, please visit the <u><a href="https://dotnetfoundation.org">new site</a></u>
+        </div>
+    </section>
+
     <div class="site-nav_container container">
         <nav class="navbar navbar-expand-md align-items-end">
             <a class="navbar-brand" href="/"><img id="site-logo" src="/img/dotNetFoundationHorizontal.svg" alt=".NET Foundation"></a>


### PR DESCRIPTION
The new version of .NET Foundation website will go live on November 8th. The site will not be fully complete, so we will be directing users to the old site for some content. In order to avoid confusion, this PR adds a banner letting folks know about the new site.